### PR TITLE
Add rttest to ros2.repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -83,6 +83,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
     version: master
+  ros2/rttest:
+    type: git
+    url: https://github.com/ros2/rttest.git
+    version: master
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git


### PR DESCRIPTION
rttest is a dependency for ros2/demos/pull/7, so in order to get CI for that PR, I am adding rttest to ros2.repos.

These CI jobs test master with the new ros2.repos:

http://ci.ros2.org/job/ros2_batch_ci_linux/231/
http://ci.ros2.org/job/ros2_batch_ci_osx/152/
http://ci.ros2.org/job/ros2_batch_ci_windows/234/

These pending CI jobs test ros2/rttest/pull/2, which will fix uncrustify errors, add a gtest, and prevent rttest from building on Windows:

http://ci.ros2.org/job/ros2_batch_ci_linux/236
http://ci.ros2.org/job/ros2_batch_ci_osx/155
http://ci.ros2.org/job/ros2_batch_ci_windows/238