### PR TITLE
Imu example

### DIFF
--- a/rclcpp_examples/CMakeLists.txt
+++ b/rclcpp_examples/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 ament_package()
@@ -41,6 +42,11 @@ add_executable_for_each_rmw_implementations(listener_memory
 add_executable_for_each_rmw_implementations(talker_memory
   src/topics/talker_memory.cpp
   TARGET_DEPENDENCIES ${target_dependencies} INSTALL)
+
+add_executable_for_each_rmw_implementations(imu_listener
+  src/topics/imu_listener.cpp
+  TARGET_DEPENDENCIES ${target_dependencies} sensor_msgs INSTALL)
+
 
 ##
 ## Examples of Request/Response with Services

--- a/rclcpp_examples/package.xml
+++ b/rclcpp_examples/package.xml
@@ -13,12 +13,14 @@
   <build_depend>example_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <export>

--- a/rclcpp_examples/src/topics/imu_listener.cpp
+++ b/rclcpp_examples/src/topics/imu_listener.cpp
@@ -1,0 +1,35 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdio>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+void imu_cb(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+{
+  printf(" accel: [%+6.3f %+6.3f %+6.3f]\n",
+    msg->linear_acceleration.x,
+    msg->linear_acceleration.y,
+    msg->linear_acceleration.z);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("imu_listener");
+  auto sub = node->create_subscription<sensor_msgs::msg::Imu>(
+    "imu", rmw_qos_profile_sensor_data, imu_cb);
+  rclcpp::spin(node);
+  return 0;
+}


### PR DESCRIPTION
This creates a minimal IMU listener example, which shows how to receive a sensor_msgs::Imu message and print the accelerometer vector to the console.