### PR TITLE
add ros1_bridge repo

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -75,6 +75,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
     version: master
+  ros2/ros1_bridge:
+    type: git
+    url: https://github.com/ros2/ros1_bridge.git
+    version: master
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git


### PR DESCRIPTION
Depends on ros2/ros1_bridge#8 to only build if ROS 1 is sourced.