### PR TITLE
Fix CTRL-C in client examples

### DIFF
--- a/rclcpp_examples/src/services/add_two_ints_client_async.cpp
+++ b/rclcpp_examples/src/services/add_two_ints_client_async.cpp
@@ -33,7 +33,11 @@ int main(int argc, char ** argv)
 
   rclcpp::spin_until_future_complete(node, result);  // Wait for the result.
 
-  std::cout << "Result of add_two_ints: " << result.get()->sum << std::endl;
+  if (result.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+    printf("Result of add_two_ints: %d\n", result.get()->sum);
+  } else {
+    printf("add_two_ints_client_async was interrupted. Exiting.\n");
+  }
 
   return 0;
 }


### PR DESCRIPTION
Connects to ros2/rmw_connext#97

The global interrupt guard condition is working for clients/spin_until_future_complete, but the problem was in how the resulting future object was used. If you call `get` on a future that isn't complete, the thread will continue blocking on that future, even though the CTRL-C interrupt was already triggered. This pull request checks the status of the future before accessing it, to avoid blocking.

It may be wise to refactor the `spin_until_future_complete` call to return a more informative error code if the call was interrupted. I see this pull request as more of a workaround to a bigger issue in the rclcpp API.