### PR TITLE
fix warnings

### DIFF
--- a/rclcpp_examples/src/services/add_two_ints_client.cpp
+++ b/rclcpp_examples/src/services/add_two_ints_client.cpp
@@ -47,7 +47,7 @@ int main(int argc, char ** argv)
   // TODO(wjwwood): consider error condition
   auto result = send_request(node, client, request);
   if (result) {
-    printf("Result of add_two_ints: %d\n", result->sum);
+    printf("Result of add_two_ints: %zu\n", result->sum);
   } else {
     printf("add_two_ints_client was interrupted. Exiting.\n");
   }

--- a/rclcpp_examples/src/services/add_two_ints_client_async.cpp
+++ b/rclcpp_examples/src/services/add_two_ints_client_async.cpp
@@ -34,7 +34,7 @@ int main(int argc, char ** argv)
   rclcpp::spin_until_future_complete(node, result);  // Wait for the result.
 
   if (result.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-    printf("Result of add_two_ints: %d\n", result.get()->sum);
+    printf("Result of add_two_ints: %zu\n", result.get()->sum);
   } else {
     printf("add_two_ints_client_async was interrupted. Exiting.\n");
   }


### PR DESCRIPTION
I introduced new warnings in ros2/examples/pull/59. This is what happens when you don't launch CI...

http://ci.ros2.org/job/ros2_batch_ci_windows/384/

I'm in favor of squashing this into the commit that introduced the warning.