### PR TITLE
Remove extra braces. Wait for the correct future.

### DIFF
--- a/rclcpp_examples/src/parameters/set_and_get_parameters_async.cpp
+++ b/rclcpp_examples/src/parameters/set_and_get_parameters_async.cpp
@@ -49,8 +49,8 @@ int main(int argc, char ** argv)
   }
 
   // Get a few of the parameters just set.
-  auto parameters = parameters_client->get_parameters({{"foo", "baz"}});
-  if (rclcpp::spin_until_future_complete(node, results) !=
+  auto parameters = parameters_client->get_parameters({"foo", "baz"});
+  if (rclcpp::spin_until_future_complete(node, parameters) !=
     rclcpp::executors::FutureReturnCode::SUCCESS)
   {
     printf("get_parameters service call failed. Exiting example.\n");


### PR DESCRIPTION
This fixes two issues in the example.