### PR TITLE
wait for service in client example

### DIFF
--- a/rclcpp_examples/src/services/add_two_ints_client_async.cpp
+++ b/rclcpp_examples/src/services/add_two_ints_client_async.cpp
@@ -13,10 +13,52 @@
 // limitations under the License.
 
 #include <iostream>
+#include <string>
 
 #include "rclcpp/rclcpp.hpp"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
+
+// This function could be considered a prototype of an API that should be
+// promoted into rclcpp. This version polls; doing it in an event-driven
+// manner would be better.
+bool wait_for_service(rclcpp::Node::SharedPtr node,
+  const std::string & topic,
+  const std::chrono::steady_clock::duration timeout)
+{
+  const std::chrono::milliseconds sleep_per_loop(1);
+  auto end = std::chrono::steady_clock::now() + timeout;
+  bool success = false;
+  bool printed = false;
+  while (std::chrono::steady_clock::now() < end) {
+    try {
+      if (node->count_subscribers(topic) == 0) {
+        success = true;
+        break;
+      }
+    } catch (std::runtime_error & e) {
+      // fastrtps doesn't yet implement rmw_count_subscribers(), but rather
+      // throws an exception instead. We'll just run out the clock and
+      // return true, hoping for the best.
+      if (!printed) {
+        fprintf(stderr, "count_subscribers() exception (this is expected for FastRTPS): %s\n",
+          e.what());
+        printed = true;
+      }
+      rmw_reset_error();
+      success = true;
+    }
+    auto remaining = end - std::chrono::steady_clock::now();
+    if (remaining < sleep_per_loop) {
+      if (remaining > std::chrono::steady_clock::duration::zero()) {
+        std::this_thread::sleep_for(remaining);
+      }
+    } else {
+      std::this_thread::sleep_for(sleep_per_loop);
+    }
+  }
+  return success;
+}
 
 int main(int argc, char ** argv)
 {
@@ -28,6 +70,11 @@ int main(int argc, char ** argv)
   auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
   request->a = 2;
   request->b = 3;
+
+  if (!wait_for_service(node, "add_two_ints", std::chrono::seconds(2))) {
+    printf("add_two_ints service not available. Exiting.\n");
+    return 1;
+  }
 
   auto future_result = client->async_send_request(request);
 


### PR DESCRIPTION
The test that uses this client example can fail if the server isn't yet up and ready to hear the client's request. In that situation, the client waits forever and the test times out, as we've [seen](http://ci.ros2.org/view/nightly/job/nightly_osx/234/testReport/junit/projectroot.Users.osrf.jenkins.workspace.nightly_osx.ws.src.ros2.examples/rclcpp_examples/test_example_add_two_ints_server_add_two_ints_client__rmw_fastrtps_cpp/) with FastRTPS. This PR adds a `wait_for_service()` call that the client uses to delay its request until the time is right.

This function should not live here in the long term, but rather be improved and promoted into client API (ros2/rclcpp#201). But this is a decent place to park it for now.