### PR TITLE
temporary try/except block around import rclpy

### DIFF
--- a/rclpy_examples/listener_py.py
+++ b/rclpy_examples/listener_py.py
@@ -14,7 +14,13 @@
 
 import sys
 
-import rclpy
+# TODO(jacquelinekay): Remove try block when rclpy supports multiple vendors!!
+try:
+    import rclpy
+except ImportError:
+    print("rclpy was not found. This could be because no valid typesupport was found.")
+    sys.exit()
+
 from rclpy.qos import qos_profile_default
 from std_msgs.msg import String
 

--- a/rclpy_examples/talker_py.py
+++ b/rclpy_examples/talker_py.py
@@ -15,7 +15,13 @@
 import sys
 from time import sleep
 
-import rclpy
+# TODO(jacquelinekay): Remove try block when rclpy supports multiple vendors!!
+try:
+    import rclpy
+except ImportError:
+    print("rclpy was not found. This could be because no valid typesupport was found.")
+    sys.exit()
+
 from rclpy.qos import qos_profile_default
 from std_msgs.msg import String
 


### PR DESCRIPTION
Connects to ros2/rosidl#99

This is a temporary workaround for the failing nosetest for these examples until rclpy works with all middlewares (ros2/rclpy#5).