### PR TITLE
Add test for rmw linking

### DIFF
--- a/rclcpp_examples/CMakeLists.txt
+++ b/rclcpp_examples/CMakeLists.txt
@@ -98,12 +98,26 @@ if(AMENT_ENABLE_TESTING)
         OUTPUT "test_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
-
       ament_add_nose_test(test_example_${exe_list_underscore}${target_suffix}
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
         TIMEOUT 30)
       set_tests_properties(test_example_${exe_list_underscore}${target_suffix}
         PROPERTIES DEPENDS "test_example_${exe_list_underscore}${target_suffix} test_example_${exe_list_underscore}${target_suffix}")
+
+      configure_file(
+        test/test_executable_linking.py.in
+        test_linking_${exe_list_underscore}${target_suffix}.py.configured
+        @ONLY
+      )
+      file(GENERATE
+        OUTPUT "test_linking_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
+        INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_linking_${exe_list_underscore}${target_suffix}.py.configured"
+      )
+      ament_add_nose_test(test_linking_${exe_list_underscore}${target_suffix}
+        "${CMAKE_CURRENT_BINARY_DIR}/test_linking_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
+        TIMEOUT 30)
+      set_tests_properties(test_linking_${exe_list_underscore}${target_suffix}
+        PROPERTIES DEPENDS "test_linking_${exe_list_underscore}${target_suffix} test_linking_${exe_list_underscore}${target_suffix}")
     endforeach()
   endmacro()
 

--- a/rclcpp_examples/test/test_executable_linking.py.in
+++ b/rclcpp_examples/test/test_executable_linking.py.in
@@ -1,7 +1,7 @@
 # generated from rclcpp_examples/test/test_executable_linking.py.in
 
 import os
-import shlex
+import re
 import subprocess 
 
 def setup():
@@ -14,14 +14,12 @@ def test_executable():
     executables = '@RCLCPP_EXAMPLES_EXECUTABLE@'.split(';')
     for exe in executables:
         # Check that the executable is linked against the claimed rmw implementation
-        proc1 = subprocess.Popen(shlex.split('ldd %s'%exe), stdout=subprocess.PIPE)
-        proc2 = subprocess.Popen(shlex.split('grep -c %s'%rmw_implementation), stdin=proc1.stdout,
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        proc1.stdout.close()
-        out, err = proc2.communicate()
-        links = int(out.decode("ASCII").strip())
-        assert links > 0, 'Executable is not linked against %s RMW implementation. %i links found.' \
-            % (rmw_implementation, links)
+        cmd = ['ldd', exe]
+        dependencies = subprocess.check_output(cmd)
+        pattern = re.compile(rmw_implementation.encode(), flags=re.IGNORECASE)
+        relevant_links = pattern.findall(dependencies)
+        assert len(relevant_links) > 0, \
+            "Executable is not linked against RMW implementation '%s'." % rmw_implementation
 
 if __name__ == '__main__':
     test_executable()

--- a/rclcpp_examples/test/test_executable_linking.py.in
+++ b/rclcpp_examples/test/test_executable_linking.py.in
@@ -1,0 +1,27 @@
+# generated from rclcpp_examples/test/test_executable_linking.py.in
+
+import os
+import shlex
+import subprocess 
+
+def setup():
+    os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+
+
+def test_executable():
+
+    rmw_implementation = '@rmw_implementation@'
+    executables = '@RCLCPP_EXAMPLES_EXECUTABLE@'.split(';')
+    for exe in executables:
+        # Check that the executable is linked against the claimed rmw implementation
+        proc1 = subprocess.Popen(shlex.split('ldd %s'%exe), stdout=subprocess.PIPE)
+        proc2 = subprocess.Popen(shlex.split('grep -c %s'%rmw_implementation), stdin=proc1.stdout,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc1.stdout.close()
+        out, err = proc2.communicate()
+        links = int(out.decode("ASCII").strip())
+        assert links > 0, 'Executable is not linked against %s RMW implementation. %i links found.' \
+            % (rmw_implementation, links)
+
+if __name__ == '__main__':
+    test_executable()


### PR DESCRIPTION
Is this headed in the right direction for https://github.com/ros2/examples/issues/96? Regression test for https://github.com/ros2/examples/commit/fda593878912e0173861c44d9600396b3e6a087f


Known issues: 
- [ ]  using ldd to check linking so not platform independent yet. 
- [ ]  checking executables more than once if they appear multiple times in [this list](https://github.com/dhood/examples/blob/4fb2668f9f09816e31d5c63f9d04fa0486cd845c/rclcpp_examples/CMakeLists.txt#L72).
- [ ] my formatting tests aren't working yet so probably issues with styling.