### PR TITLE
Only filter RTI licence output on connext executables

### DIFF
--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -35,16 +35,14 @@ def test_executable():
         filtered_prefixes = [
             b'pid', b'rc',
         ]
-
-        if rmw_implementation == 'rmw_connext_cpp' \
-            or rmw_implementation == 'rmw_connext_dynamic_cpp':
+        if rmw_implementation in ['rmw_connext_cpp', 'rmw_connext_dynamic_cpp']:
             filtered_prefixes.extend([
                 b'RTI Data Distribution Service',
                 b'Expires on',
             ])
             
-        handler = create_handler(name, launch_descriptor, output_file, \
-                                 exit_on_match=exit_on_match, filtered_prefixes=filtered_prefixes)
+        handler = create_handler(name, launch_descriptor, output_file, 
+            exit_on_match=exit_on_match, filtered_prefixes=filtered_prefixes)
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -33,7 +33,7 @@ def test_executable():
             exit_on_match = False
 
         handler = create_handler(name, launch_descriptor, output_file, 
-            exit_on_match=exit_on_match, filtered_rmw_implementations=[rmw_implementation])
+            exit_on_match=exit_on_match, filtered_rmw_implementation=rmw_implementation)
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -33,7 +33,7 @@ def test_executable():
             exit_on_match = False
 
         handler = create_handler(name, launch_descriptor, output_file, 
-            exit_on_match=exit_on_match, rmw_implementations_to_filter=[rmw_implementation])
+            exit_on_match=exit_on_match, filtered_rmw_implementations=[rmw_implementation])
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -32,15 +32,8 @@ def test_executable():
             exit_handler = ignore_exit_handler
             exit_on_match = False
 
-        additional_filtered_prefixes = None
-        has_license_output = ament_index_python.has_resource('dds_license_output', rmw_implementation)
-        if has_license_output:
-            license_output = ament_index_python.get_resource('dds_license_output', rmw_implementation)
-            license_output_lines = license_output.strip().split('\n')
-            additional_filtered_prefixes = [ str.encode(line) for line in license_output_lines]
-            
         handler = create_handler(name, launch_descriptor, output_file, 
-            exit_on_match=exit_on_match, additional_filtered_prefixes=additional_filtered_prefixes)
+            exit_on_match=exit_on_match, rmw_implementations_to_filter=[rmw_implementation])
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -18,6 +18,7 @@ def test_executable():
 
     launch_descriptor = LaunchDescriptor()
 
+    rmw_implementation = '@rmw_implementation@'
     executables = '@RCLCPP_EXAMPLES_EXECUTABLE@'.split(';')
     output_files = '@RCLCPP_EXAMPLES_EXPECTED_OUTPUT@'.split(';')
     for i, (exe, output_file) in enumerate(zip(executables, output_files)):
@@ -30,7 +31,20 @@ def test_executable():
         else:
             exit_handler = ignore_exit_handler
             exit_on_match = False
-        handler = create_handler(name, launch_descriptor, output_file, exit_on_match=exit_on_match)
+
+        filtered_prefixes = [
+            b'pid', b'rc',
+        ]
+
+        if rmw_implementation == 'rmw_connext_cpp' \
+            or rmw_implementation == 'rmw_connext_dynamic_cpp':
+            filtered_prefixes.extend([
+                b'RTI Data Distribution Service',
+                b'Expires on',
+            ])
+            
+        handler = create_handler(name, launch_descriptor, output_file, \
+                                 exit_on_match=exit_on_match, filtered_prefixes=filtered_prefixes)
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -7,7 +7,7 @@ from launch.exit_handler import primary_ignore_returncode_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-
+import ament_index_python
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
@@ -32,17 +32,15 @@ def test_executable():
             exit_handler = ignore_exit_handler
             exit_on_match = False
 
-        filtered_prefixes = [
-            b'pid', b'rc',
-        ]
-        if rmw_implementation in ['rmw_connext_cpp', 'rmw_connext_dynamic_cpp']:
-            filtered_prefixes.extend([
-                b'RTI Data Distribution Service',
-                b'Expires on',
-            ])
+        additional_filtered_prefixes = None
+        has_license_output = ament_index_python.has_resource('dds_license_output', rmw_implementation)
+        if has_license_output:
+            license_output = ament_index_python.get_resource('dds_license_output', rmw_implementation)
+            license_output_lines = license_output.strip().split('\n')
+            additional_filtered_prefixes = [ str.encode(line) for line in license_output_lines]
             
         handler = create_handler(name, launch_descriptor, output_file, 
-            exit_on_match=exit_on_match, filtered_prefixes=filtered_prefixes)
+            exit_on_match=exit_on_match, additional_filtered_prefixes=additional_filtered_prefixes)
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/rclcpp_examples/test/test_executables_example.py.in
+++ b/rclcpp_examples/test/test_executables_example.py.in
@@ -7,7 +7,6 @@ from launch.exit_handler import primary_ignore_returncode_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-import ament_index_python
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE


### PR DESCRIPTION
I think the bug fixed by https://github.com/ros2/examples/commit/fda593878912e0173861c44d9600396b3e6a087f took so long to spot because the RTI licence output was being filtered for all executables, so it wasn't obvious when others were linking against connext

connects to ros2/launch#24