### PR TITLE
move message import temporarily

### DIFF
--- a/rclpy_examples/listener_py.py
+++ b/rclpy_examples/listener_py.py
@@ -38,7 +38,8 @@ def main(args=None):
     sub = node.create_subscription(String, 'chatter', chatter_callback, qos_profile_default)
     assert sub  # prevent unused warning
 
-    rclpy.spin(node)
+    while rclpy.ok():
+        rclpy.spin_once(node)
 
 if __name__ == '__main__':
     main()

--- a/rclpy_examples/listener_py.py
+++ b/rclpy_examples/listener_py.py
@@ -14,15 +14,9 @@
 
 import sys
 
-# TODO(jacquelinekay): Remove try block when rclpy supports multiple vendors!!
-try:
-    import rclpy
-except ImportError:
-    print("rclpy was not found. This could be because no valid typesupport was found.")
-    sys.exit()
+import rclpy
 
 from rclpy.qos import qos_profile_default
-from std_msgs.msg import String
 
 
 def chatter_callback(msg):
@@ -34,6 +28,10 @@ def main(args=None):
         args = sys.argv
 
     rclpy.init(args)
+
+    # TODO(wjwwood): move this import back to the top of the file when
+    # it is possible to import the messages before rclpy.init().
+    from std_msgs.msg import String
 
     node = rclpy.create_node('listener')
 

--- a/rclpy_examples/talker_py.py
+++ b/rclpy_examples/talker_py.py
@@ -42,6 +42,7 @@ def main(args=None):
         i += 1
         print('Publishing: "{0}"'.format(msg.data))
         chatter_pub.publish(msg)
+        # TODO(wjwwood): need to spin_some or spin_once with timeout
         sleep(1)
 
 if __name__ == '__main__':

--- a/rclpy_examples/talker_py.py
+++ b/rclpy_examples/talker_py.py
@@ -15,15 +15,9 @@
 import sys
 from time import sleep
 
-# TODO(jacquelinekay): Remove try block when rclpy supports multiple vendors!!
-try:
-    import rclpy
-except ImportError:
-    print("rclpy was not found. This could be because no valid typesupport was found.")
-    sys.exit()
+import rclpy
 
 from rclpy.qos import qos_profile_default
-from std_msgs.msg import String
 
 
 def main(args=None):
@@ -31,6 +25,10 @@ def main(args=None):
         args = sys.argv
 
     rclpy.init(args)
+
+    # TODO(wjwwood): move this import back to the top of the file when
+    # it is possible to import the messages before rclpy.init().
+    from std_msgs.msg import String
 
     node = rclpy.create_node('talker')
 


### PR DESCRIPTION
Otherwise you get something like this for the Python examples:

```
% python3 ./bin/listener_py
Traceback (most recent call last):
  File "./bin/listener_py", line 9, in <module>
    load_entry_point('rclpy-examples==0.0.0', 'console_scripts', 'listener_py')()
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 549, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2542, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2202, in load
    return self.resolve()
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2208, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/tmp/testing_alpha5/ros2-osx/lib/python3.5/site-packages/listener_py.py", line 25, in <module>
    from std_msgs.msg import String
  File "/tmp/testing_alpha5/ros2-osx/lib/python3.5/site-packages/std_msgs/msg/__init__.py", line 1, in <module>
    from std_msgs.msg._bool import Bool
  File "/tmp/testing_alpha5/ros2-osx/lib/python3.5/site-packages/std_msgs/msg/_bool.py", line 20, in <module>
    rclpy_implementation = rclpy._rclpy.rclpy_get_rmw_implementation_identifier()
  File "/tmp/testing_alpha5/ros2-osx/lib/python3.5/site-packages/rclpy/impl/object_proxy.py", line 36, in __getattribute__
    return getattr(subject, attr)
  File "/tmp/testing_alpha5/ros2-osx/lib/python3.5/site-packages/rclpy/impl/implementation_singleton.py", line 47, in __getattr__
    raise NotInitializedException()
rclpy.exceptions.NotInitializedException: rclpy.init() has not been called
```