### PR TITLE
Remove unused rmw typesupport call

### DIFF
--- a/rclcpp_examples/CMakeLists.txt
+++ b/rclcpp_examples/CMakeLists.txt
@@ -80,9 +80,6 @@ if(AMENT_ENABLE_TESTING)
         list(APPEND RCLCPP_EXAMPLES_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/${executable}")
       endforeach()
 
-      # get typesupport of rmw implementation to include / link against the corresponding interfaces
-      get_rmw_typesupport(typesupport_impl "${rmw_implementation}")
-
       set(RCLCPP_EXAMPLES_EXECUTABLE "")
       foreach(executable ${example_executables})
         list(APPEND RCLCPP_EXAMPLES_EXECUTABLE "$<TARGET_FILE:${executable}${target_suffix}>")


### PR DESCRIPTION
While working on ros2/rmw#63 I noticed that this call is never used, so I'm removing it (similar to ros2/demos#63).