### PR TITLE
Verify rmw implementation of rclcpp examples at runtime

### DIFF
--- a/rclcpp_examples/CMakeLists.txt
+++ b/rclcpp_examples/CMakeLists.txt
@@ -98,7 +98,8 @@ if(AMENT_ENABLE_TESTING)
 
       ament_add_nose_test(test_example_${exe_list_underscore}${target_suffix}
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
-        TIMEOUT 30)
+        TIMEOUT 30
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
       set_tests_properties(test_example_${exe_list_underscore}${target_suffix}
         PROPERTIES DEPENDS "test_example_${exe_list_underscore}${target_suffix} test_example_${exe_list_underscore}${target_suffix}")
     endforeach()

--- a/rclcpp_examples/package.xml
+++ b/rclcpp_examples/package.xml
@@ -24,7 +24,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Modifies existing `rclcpp_examples` tests to act as a regression test for https://github.com/ros2/examples/commit/fda593878912e0173861c44d9600396b3e6a087f (in comparison to #105 which adds new tests to explicitly check the linking)

Currently just for `talker` - once approved I can extend to the other executables

Note that I had to modify the exit handler used in the tests in order to get them to fail with the non-zero return code from `talker` (when https://github.com/ros2/examples/commit/fda593878912e0173861c44d9600396b3e6a087f is reverted). This does not seem to have any negative side-effects (no regressions in CI). As a result, I am not entirely clear on the reason it was `ignore_exit_handler` before, given that it suppresses errors and seems to have been unnecessary. So, please be extra skeptical of [this change](https://github.com/dhood/examples/commit/27aa2164156d06d54ae8c2cd5596d1215544db6d#diff-1988d847d73fdc4f80e5573bb07a0466R31) in this PR.

http://ci.ros2.org/job/ci_windows/1265/
http://ci.ros2.org/job/ci_linux/1218/
http://ci.ros2.org/job/ci_osx/983/

Connects to ros2/examples#96