### PR TITLE
Updated the service server example

### DIFF
--- a/rclcpp_examples/src/services/add_two_ints_server.cpp
+++ b/rclcpp_examples/src/services/add_two_ints_server.cpp
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("add_two_ints_server");
 
-  auto client = node->create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
+  auto server = node->create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
 
   rclcpp::spin(node);
 

--- a/rclcpp_examples/src/services/add_two_ints_server.cpp
+++ b/rclcpp_examples/src/services/add_two_ints_server.cpp
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("add_two_ints_server");
 
-  node->create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
+  auto client = node->create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
 
   rclcpp::spin(node);
 


### PR DESCRIPTION
There must be at least one shared pointer to the service instance
so it is not destroyed.