### PR TITLE
Re-enable service tests for connext

### DIFF
--- a/rclcpp_examples/CMakeLists.txt
+++ b/rclcpp_examples/CMakeLists.txt
@@ -77,15 +77,7 @@ if(BUILD_TESTING)
 
   macro(tests)
     set(example_tests_to_test ${example_tests})
-    # TODO(wjwwood): recombine with example_tests this when all rmw supports wait_for_service.
-    if(
-      NOT rmw_implementation STREQUAL "rmw_opensplice_cpp" AND
-      NOT rmw_implementation STREQUAL "rmw_fastrtps_cpp"
-    )
-      message(STATUS "Skipping service example tests for '${rmw_implementation}'")
-    else()
-      list(APPEND example_tests_to_test ${service_example_tests})
-    endif()
+    list(APPEND example_tests_to_test ${service_example_tests})
 
     foreach(example_test ${example_tests_to_test})
       string(REPLACE ":" ";" example_executables "${example_test}")


### PR DESCRIPTION
This probably could have been changed since https://github.com/ros2/rmw_connext/pull/165

This PR doesn't necessarily connect to https://github.com/ros2/rmw_connext/issues/168, but it has the same branch name so that these tests can be enabled on the CI jobs for the other PRs with the `local_graph_changes` branch name.