### PR TITLE
Added a service mapping rule

### DIFF
--- a/example_interfaces/CMakeLists.txt
+++ b/example_interfaces/CMakeLists.txt
@@ -16,4 +16,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces
 )
 
+install(FILES service_mapping_rules.yaml DESTINATION share/${PROJECT_NAME})
+
 ament_package()

--- a/example_interfaces/package.xml
+++ b/example_interfaces/package.xml
@@ -18,5 +18,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <ros1_bridge service_mapping_rules="service_mapping_rules.yaml"/>
   </export>
 </package>

--- a/example_interfaces/service_mapping_rules.yaml
+++ b/example_interfaces/service_mapping_rules.yaml
@@ -1,0 +1,5 @@
+-
+  ros1_package_name: 'roscpp_tutorials'
+  ros1_service_name: 'TwoInts'
+  ros2_package_name: 'example_interfaces'
+  ros2_service_name: 'AddTwoInts'


### PR DESCRIPTION
It enables ros1_bridge to connect the AddTwoInts service
from this package with the TwoInts from ros/roscpp_tutorials.

See issue https://github.com/ros2/ros1_bridge/issues/33

Connect to ros2/ros1_bridge#36