### PR TITLE
Removed message type from the template list in create_subscription

### DIFF
--- a/rclcpp/minimal_subscriber/lambda.cpp
+++ b/rclcpp/minimal_subscriber/lambda.cpp
@@ -22,7 +22,7 @@ public:
   MinimalSubscriber()
   : Node("minimal_subscriber")
   {
-    subscription_ = this->create_subscription<std_msgs::msg::String>(
+    subscription_ = this->create_subscription(
       "topic",
       [](std_msgs::msg::String::UniquePtr msg) {
       printf("I heard: [%s]\n", msg->data.c_str());

--- a/rclcpp/minimal_subscriber/member_function.cpp
+++ b/rclcpp/minimal_subscriber/member_function.cpp
@@ -22,7 +22,7 @@ public:
   MinimalSubscriber()
   : Node("minimal_subscriber")
   {
-    subscription_ = this->create_subscription<std_msgs::msg::String>(
+    subscription_ = this->create_subscription(
       "topic", std::bind(&MinimalSubscriber::topic_callback, this, _1));
   }
 

--- a/rclcpp/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/minimal_subscriber/not_composable.cpp
@@ -29,8 +29,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::node::Node::make_shared("minimal_subscriber");
-  auto subscription = node->create_subscription<std_msgs::msg::String>
-      ("topic", topic_callback);
+  auto subscription = node->create_subscription("topic", topic_callback);
   rclcpp::spin(node);
   return 0;
 }


### PR DESCRIPTION
This simplifies some of the examples so the message type is not passed twice.

Connects to ros2/rclcpp#286