### PR TITLE
fix #138 with cross-platform C99 printf specifiers

### DIFF
--- a/rclcpp/minimal_client/main.cpp
+++ b/rclcpp/minimal_client/main.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
 #include <memory>
 #include "example_interfaces/srv/add_two_ints.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -41,7 +42,7 @@ int main(int argc, char * argv[])
     return 1;
   }
   auto result = result_future.get();
-  printf("result of sending service request for %ld + %ld = %ld\n",
+  printf("result of %" PRId64 " + %" PRId64 " = %" PRId64 "\n",
     request->a, request->b, result->sum);
   return 0;
 }

--- a/rclcpp/minimal_service/main.cpp
+++ b/rclcpp/minimal_service/main.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
 #include <memory>
 #include "example_interfaces/srv/add_two_ints.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -24,7 +25,7 @@ void handle_service(
   const std::shared_ptr<AddTwoInts::Response> response)
 {
   (void)request_header;
-  printf("request: %ld + %ld\n", request->a, request->b);
+  printf("request: %" PRId64 " + %" PRId64 "\n", request->a, request->b);
   response->sum = request->a + request->b;
 }
 


### PR DESCRIPTION
It works! :tada: :balloon: :hamburger: 

Green lights everywhere! No warnings! No errors!

Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2028)](http://ci.ros2.org/job/ci_linux/2028)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1557)](http://ci.ros2.org/job/ci_osx/1557/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2009)](http://ci.ros2.org/job/ci_windows/2009/)