### PR TITLE
remove unused srv file

### DIFF
--- a/rclcpp/minimal_service/package.xml
+++ b/rclcpp/minimal_service/package.xml
@@ -8,7 +8,6 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>example_interfaces</build_depend>

--- a/rclcpp/minimal_service/srv/AddTwoInts.srv
+++ b/rclcpp/minimal_service/srv/AddTwoInts.srv
@@ -1,4 +1,0 @@
-int64 a
-int64 b
----
-int64 sum


### PR DESCRIPTION
this example uses the service defined in [example_interfaces](https://github.com/ros2/examples/blob/25c091cf4418f22437fe61dcf18753310a501e03/example_interfaces/srv/AddTwoInts.srv) package so this one can be removed