### PR TITLE
fix error when exiting scripts

### DIFF
--- a/rclpy/services/minimal_client/client.py
+++ b/rclpy/services/minimal_client/client.py
@@ -43,6 +43,9 @@ def main(args=None):
         'Result of add_two_ints: for %d + %d = %d' %
         (req.a, req.b, cli.response.sum))
 
+    node.destroy_node()
+    rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/rclpy/services/minimal_client/client_async.py
+++ b/rclpy/services/minimal_client/client_async.py
@@ -45,6 +45,7 @@ def main(args=None):
             break
         rclpy.spin_once(node)
 
+    node.destroy_node()
     rclpy.shutdown()
 
 

--- a/rclpy/services/minimal_client/client_async_member_function.py
+++ b/rclpy/services/minimal_client/client_async_member_function.py
@@ -53,6 +53,7 @@ def main(args=None):
             break
         rclpy.spin_once(node)
 
+    node.destroy_node()
     rclpy.shutdown()
 
 


### PR DESCRIPTION
Fixes an error with `rmw_connext_cpp` when existing the async scripts. Updated the sync script to match the same behavior.

I didn't run any CI builds since this isn't covered anyway.

Ready for review.