### PR TITLE
Prototype use of rclpy logging for callback_group

### DIFF
--- a/rclpy/executors/examples_rclpy_executors/callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/callback_group.py
@@ -26,8 +26,8 @@ logger = rclpy.logging.get_named_logger('callback_group_example')
 class DoubleTalker(rclpy.Node):
     """Publish messages to a topic using two publishers at different rates."""
 
-    def __init__(self, parent_logger=None):
-        super().__init__('double_talker', parent_logger=parent_logger)
+    def __init__(self, **node_init_args):
+        super().__init__('double_talker', **node_init_args)
 
         self.i = 0
         self.pub = self.create_publisher(String, 'chatter')

--- a/rclpy/executors/examples_rclpy_executors/listener.py
+++ b/rclpy/executors/examples_rclpy_executors/listener.py
@@ -25,9 +25,9 @@ class Listener(rclpy.Node):
     other scripts.
     """
 
-    def __init__(self, parent_logger=None):
+    def __init__(self, **node_init_args):
         # Calls rclpy.Node.__init__('listener')
-        super().__init__('listener', parent_logger=parent_logger)
+        super().__init__('listener', **node_init_args)
         self.sub = self.create_subscription(String, 'chatter', self.chatter_callback)
 
     def chatter_callback(self, msg):

--- a/rclpy/executors/examples_rclpy_executors/listener.py
+++ b/rclpy/executors/examples_rclpy_executors/listener.py
@@ -25,13 +25,13 @@ class Listener(rclpy.Node):
     other scripts.
     """
 
-    def __init__(self):
+    def __init__(self, parent_logger=None):
         # Calls rclpy.Node.__init__('listener')
-        super().__init__('listener')
+        super().__init__('listener', parent_logger=parent_logger)
         self.sub = self.create_subscription(String, 'chatter', self.chatter_callback)
 
     def chatter_callback(self, msg):
-        print('I heard: [%s]' % msg.data)
+        self.logger.info('I heard: [%s]' % msg.data)
 
 
 def main(args=None):


### PR DESCRIPTION
Is this what we expect this example to look like using rclpy logging?
The script passes its logger (`ros.callback_group_example`) through to the nodes so that the node loggers get attached to the parent logger.

The logger name of the nodes gets the parent logger prepended:
```
[INFO] [ros.callback_group_example.double_talker]: Publishing: "Hello World: 0"
[INFO] [ros.callback_group_example.listener]: I heard: [Hello World: 0]
[INFO] [ros.callback_group_example.double_talker]: Publishing: "Hello World: 1"
[INFO] [ros.callback_group_example.double_talker]: Publishing: "Hello World: 2"
[INFO] [ros.callback_group_example.listener]: I heard: [Hello World: 1]
```

And if you enable debug on the parent logger (by uncommenting https://github.com/ros2/examples/compare/master...use_logging#diff-41999062ba992334cbe0288b618f2a2dR23), the node loggers get debug enabled too:
```
[DEBUG] [ros.callback_group_example.double_talker]: Initialization complete
[DEBUG] [ros.callback_group_example]: Nodes added to executor
[INFO] [ros.callback_group_example.double_talker]: Publishing: "Hello World: 0"
[INFO] [ros.callback_group_example.listener]: I heard: [Hello World: 0]
```


If you don't pass through the script's logger, the nodes will just use independent loggers (still configurable, but not attached to the parent, and the logger name will collide with any other nodes with the same node name).