### PR TITLE
Control shared/static linking via BUILD_SHARED_LIBS and CMAKE_TOOLCHAIN_FILE

### DIFF
--- a/rclcpp/minimal_client/CMakeLists.txt
+++ b/rclcpp/minimal_client/CMakeLists.txt
@@ -10,11 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
-endif()
-
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 

--- a/rclcpp/minimal_client/CMakeLists.txt
+++ b/rclcpp/minimal_client/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/rclcpp/minimal_client/package.xml
+++ b/rclcpp/minimal_client/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="morgan@osrfoundation.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>example_interfaces</build_depend>

--- a/rclcpp/minimal_publisher/CMakeLists.txt
+++ b/rclcpp/minimal_publisher/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/rclcpp/minimal_publisher/CMakeLists.txt
+++ b/rclcpp/minimal_publisher/CMakeLists.txt
@@ -10,11 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
-endif()
-
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 

--- a/rclcpp/minimal_publisher/package.xml
+++ b/rclcpp/minimal_publisher/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="morgan@osrfoundation.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/rclcpp/minimal_service/CMakeLists.txt
+++ b/rclcpp/minimal_service/CMakeLists.txt
@@ -10,11 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
-endif()
-
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 

--- a/rclcpp/minimal_service/CMakeLists.txt
+++ b/rclcpp/minimal_service/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/rclcpp/minimal_service/package.xml
+++ b/rclcpp/minimal_service/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="morgan@osrfoundation.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>example_interfaces</build_depend>

--- a/rclcpp/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/minimal_subscriber/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/rclcpp/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/minimal_subscriber/CMakeLists.txt
@@ -10,11 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
-endif()
-
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 

--- a/rclcpp/minimal_subscriber/package.xml
+++ b/rclcpp/minimal_subscriber/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="morgan@osrfoundation.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/rclcpp/minimal_timer/CMakeLists.txt
+++ b/rclcpp/minimal_timer/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 

--- a/rclcpp/minimal_timer/CMakeLists.txt
+++ b/rclcpp/minimal_timer/CMakeLists.txt
@@ -10,11 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -pthread")
-endif()
-
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(timer_lambda lambda.cpp)

--- a/rclcpp/minimal_timer/package.xml
+++ b/rclcpp/minimal_timer/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="morgan@osrfoundation.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
 


### PR DESCRIPTION
This PR will allow the static linking of the example applications. 

minimal_composition is not added as it have more dependencies with
others ROS2 packages.

connects to ros2/ros2#306