### PR TITLE
Fix import statement and usage for rclpy.node.Node

### DIFF
--- a/rclpy/executors/examples_rclpy_executors/callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/callback_group.py
@@ -16,10 +16,11 @@ from examples_rclpy_executors.listener import Listener
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
 from std_msgs.msg import String
 
 
-class DoubleTalker(rclpy.Node):
+class DoubleTalker(Node):
     """Publish messages to a topic using two publishers at different rates."""
 
     def __init__(self):

--- a/rclpy/executors/examples_rclpy_executors/listener.py
+++ b/rclpy/executors/examples_rclpy_executors/listener.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.node import Node
 from std_msgs.msg import String
 
 
-class Listener(rclpy.Node):
+class Listener(Node):
     """
     A node with a single subscriber.
 
     This class creates a node which prints messages it receives on a topic. Creating a node by
-    inheriting from rclpy.Node is recommended because it allows it to be imported and used by
+    inheriting from Node is recommended because it allows it to be imported and used by
     other scripts.
     """
 
     def __init__(self):
-        # Calls rclpy.Node.__init__('listener')
+        # Calls Node.__init__('listener')
         super().__init__('listener')
         self.sub = self.create_subscription(String, 'chatter', self.chatter_callback)
 

--- a/rclpy/executors/examples_rclpy_executors/talker.py
+++ b/rclpy/executors/examples_rclpy_executors/talker.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.node import Node
 from std_msgs.msg import String
 
 
-class Talker(rclpy.Node):
+class Talker(Node):
     """
     A node with a single publisher.
 
     This class creates a node which regularly publishes messages on a topic. Creating a node by
-    inheriting from rclpy.Node is recommended because it allows it to be imported and used by
+    inheriting from Node is recommended because it allows it to be imported and used by
     other scripts.
     """
 
     def __init__(self):
-        # Calls rclpy.Node.__init__('talker')
+        # Calls Node.__init__('talker')
         super().__init__('talker')
         self.i = 0
         self.pub = self.create_publisher(String, 'chatter')

--- a/rclpy/services/minimal_client/client_async_member_function.py
+++ b/rclpy/services/minimal_client/client_async_member_function.py
@@ -17,9 +17,10 @@ import time
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.node import Node
 
 
-class MinimalClientAsync(rclpy.Node):
+class MinimalClientAsync(Node):
 
     def __init__(self):
         super().__init__('minimal_client_async')

--- a/rclpy/services/minimal_service/service_member_function.py
+++ b/rclpy/services/minimal_service/service_member_function.py
@@ -15,9 +15,10 @@
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.node import Node
 
 
-class MinimalService(rclpy.Node):
+class MinimalService(Node):
 
     def __init__(self):
         super().__init__('minimal_service')

--- a/rclpy/topics/minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/publisher_member_function.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.node import Node
 
 from std_msgs.msg import String
 
 
-class MinimalPublisher(rclpy.Node):
+class MinimalPublisher(Node):
 
     def __init__(self):
         super().__init__('minimal_publisher')

--- a/rclpy/topics/minimal_subscriber/subscriber_member_function.py
+++ b/rclpy/topics/minimal_subscriber/subscriber_member_function.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.node import Node
 
 from std_msgs.msg import String
 
 
-class MinimalSubscriber(rclpy.Node):
+class MinimalSubscriber(Node):
 
     def __init__(self):
         super().__init__('minimal_subscriber')


### PR DESCRIPTION
node is not imported in `__init__.py` anymore (https://github.com/ros2/rclpy/pull/147)

Without this change the examples raise:
`AttributeError: module 'rclpy' has not attribute 'Node'`

Not sure if https://github.com/ros2/rclpy/pull/147 is a long term fix as this mean that anyone inheriting from Node will need to import it explicitly.

connects to ros2/demos#196