### PR TITLE
Use logging

### DIFF
--- a/rclcpp/minimal_client/main.cpp
+++ b/rclcpp/minimal_client/main.cpp
@@ -27,10 +27,10 @@ int main(int argc, char * argv[])
   auto client = node->create_client<AddTwoInts>("add_two_ints");
   while (!client->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
-      printf("client interrupted while waiting for service to appear.\n");
+      RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.")
       return 1;
     }
-    printf("waiting for service to appear...\n");
+    RCLCPP_ERROR(node->get_logger(), "waiting for service to appear...")
   }
   auto request = std::make_shared<AddTwoInts::Request>();
   request->a = 41;
@@ -39,12 +39,12 @@ int main(int argc, char * argv[])
   if (rclcpp::spin_until_future_complete(node, result_future) !=
     rclcpp::executor::FutureReturnCode::SUCCESS)
   {
-    printf("service call failed :(\n");
+    RCLCPP_ERROR(node->get_logger(), "service call failed :(")
     return 1;
   }
   auto result = result_future.get();
-  printf("result of %" PRId64 " + %" PRId64 " = %" PRId64 "\n",
-    request->a, request->b, result->sum);
+  RCLCPP_INFO(node->get_logger(), "result of %" PRId64 " + %" PRId64 " = %" PRId64,
+    request->a, request->b, result->sum)
   rclcpp::shutdown();
   return 0;
 }

--- a/rclcpp/minimal_client/main.cpp
+++ b/rclcpp/minimal_client/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char * argv[])
       RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.")
       return 1;
     }
-    RCLCPP_ERROR(node->get_logger(), "waiting for service to appear...")
+    RCLCPP_INFO(node->get_logger(), "waiting for service to appear...")
   }
   auto request = std::make_shared<AddTwoInts::Request>();
   request->a = 41;

--- a/rclcpp/minimal_composition/src/publisher_node.cpp
+++ b/rclcpp/minimal_composition/src/publisher_node.cpp
@@ -30,7 +30,7 @@ void PublisherNode::on_timer()
 {
   auto message = std_msgs::msg::String();
   message.data = "Hello, world! " + std::to_string(count_++);
-  printf("Publisher: [%s]\n", message.data.c_str());
+  RCLCPP_INFO(this->get_logger(), "Publisher: '%s'", message.data.c_str())
   publisher_->publish(message);
 }
 

--- a/rclcpp/minimal_composition/src/subscriber_node.cpp
+++ b/rclcpp/minimal_composition/src/subscriber_node.cpp
@@ -21,8 +21,8 @@ SubscriberNode::SubscriberNode()
 {
   subscription_ = create_subscription<std_msgs::msg::String>(
     "topic",
-    [](std_msgs::msg::String::UniquePtr msg) {
-    printf("Subscriber: [%s]\n", msg->data.c_str());
+    [this](std_msgs::msg::String::UniquePtr msg) {
+    RCLCPP_INFO(this->get_logger(), "Subscriber: '%s'", msg->data.c_str())
   });
 }
 

--- a/rclcpp/minimal_publisher/lambda.cpp
+++ b/rclcpp/minimal_publisher/lambda.cpp
@@ -32,7 +32,7 @@ public:
       [this]() -> void {
         auto message = std_msgs::msg::String();
         message.data = "Hello, world! " + std::to_string(this->count_++);
-        printf("Publishing: [%s]\n", message.data.c_str());
+        RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str())
         this->publisher_->publish(message);
       };
     timer_ = this->create_wall_timer(500ms, timer_callback);

--- a/rclcpp/minimal_publisher/member_function.cpp
+++ b/rclcpp/minimal_publisher/member_function.cpp
@@ -36,7 +36,7 @@ private:
   {
     auto message = std_msgs::msg::String();
     message.data = "Hello, world! " + std::to_string(count_++);
-    printf("Publishing: [%s]\n", message.data.c_str());
+    RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str())
     publisher_->publish(message);
   }
   rclcpp::TimerBase::SharedPtr timer_;

--- a/rclcpp/minimal_publisher/not_composable.cpp
+++ b/rclcpp/minimal_publisher/not_composable.cpp
@@ -34,7 +34,7 @@ int main(int argc, char * argv[])
 
   while (rclcpp::ok()) {
     message->data = "Hello, world! " + std::to_string(publish_count++);
-    printf("Publishing: [%s]\n", message->data.c_str());
+    RCLCPP_INFO(node->get_logger(), "Publishing: '%s'", message->data.c_str())
     publisher->publish(message);
     rclcpp::spin_some(node);
     loop_rate.sleep();

--- a/rclcpp/minimal_service/main.cpp
+++ b/rclcpp/minimal_service/main.cpp
@@ -25,7 +25,9 @@ void handle_service(
   const std::shared_ptr<AddTwoInts::Response> response)
 {
   (void)request_header;
-  printf("request: %" PRId64 " + %" PRId64 "\n", request->a, request->b);
+  RCLCPP_INFO(
+    rclcpp::get_logger("minimal_service"),
+    "request: %" PRId64 " + %" PRId64, request->a, request->b)
   response->sum = request->a + request->b;
 }
 

--- a/rclcpp/minimal_service/main.cpp
+++ b/rclcpp/minimal_service/main.cpp
@@ -18,6 +18,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 using AddTwoInts = example_interfaces::srv::AddTwoInts;
+rclcpp::Node::SharedPtr g_node = nullptr;
 
 void handle_service(
   const std::shared_ptr<rmw_request_id_t> request_header,
@@ -26,7 +27,7 @@ void handle_service(
 {
   (void)request_header;
   RCLCPP_INFO(
-    rclcpp::get_logger("minimal_service"),
+    g_node->get_logger(),
     "request: %" PRId64 " + %" PRId64, request->a, request->b)
   response->sum = request->a + request->b;
 }
@@ -34,9 +35,9 @@ void handle_service(
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("minimal_service");
-  auto server = node->create_service<AddTwoInts>("add_two_ints", handle_service);
-  rclcpp::spin(node);
+  g_node = rclcpp::Node::make_shared("minimal_service");
+  auto server = g_node->create_service<AddTwoInts>("add_two_ints", handle_service);
+  rclcpp::spin(g_node);
   rclcpp::shutdown();
   return 0;
 }

--- a/rclcpp/minimal_subscriber/lambda.cpp
+++ b/rclcpp/minimal_subscriber/lambda.cpp
@@ -24,8 +24,8 @@ public:
   {
     subscription_ = this->create_subscription<std_msgs::msg::String>(
       "topic",
-      [](std_msgs::msg::String::UniquePtr msg) {
-      printf("I heard: [%s]\n", msg->data.c_str());
+      [this](std_msgs::msg::String::UniquePtr msg) {
+      RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str())
     });
   }
 

--- a/rclcpp/minimal_subscriber/member_function.cpp
+++ b/rclcpp/minimal_subscriber/member_function.cpp
@@ -29,7 +29,7 @@ public:
 private:
   void topic_callback(const std_msgs::msg::String::SharedPtr msg)
   {
-    printf("I heard: [%s]\n", msg->data.c_str());
+    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str())
   }
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
 };

--- a/rclcpp/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/minimal_subscriber/not_composable.cpp
@@ -22,7 +22,7 @@
 
 void topic_callback(const std_msgs::msg::String::SharedPtr msg)
 {
-  printf("I heard: [%s]\n", msg->data.c_str());
+  RCLCPP_INFO(rclcpp::get_logger("minimal_subscriber"), "I heard: '%s'", msg->data.c_str())
 }
 
 int main(int argc, char * argv[])

--- a/rclcpp/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/minimal_subscriber/not_composable.cpp
@@ -30,7 +30,7 @@ void topic_callback(const std_msgs::msg::String::SharedPtr msg)
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  auto g_node = rclcpp::node::Node::make_shared("minimal_subscriber");
+  auto g_node = rclcpp::Node::make_shared("minimal_subscriber");
   auto subscription = g_node->create_subscription<std_msgs::msg::String>
       ("topic", topic_callback);
   rclcpp::spin(g_node);

--- a/rclcpp/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/minimal_subscriber/not_composable.cpp
@@ -15,6 +15,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
+rclcpp::Node::SharedPtr g_node = nullptr;
+
 /* We do not recommend this style anymore, because composition of multiple
  * nodes in the same executable is not possible. Please see one of the subclass
  * examples for the "new" recommended styles. This example is only included
@@ -22,16 +24,16 @@
 
 void topic_callback(const std_msgs::msg::String::SharedPtr msg)
 {
-  RCLCPP_INFO(rclcpp::get_logger("minimal_subscriber"), "I heard: '%s'", msg->data.c_str())
+  RCLCPP_INFO(g_node->get_logger(), "I heard: '%s'", msg->data.c_str())
 }
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::node::Node::make_shared("minimal_subscriber");
-  auto subscription = node->create_subscription<std_msgs::msg::String>
+  auto g_node = rclcpp::node::Node::make_shared("minimal_subscriber");
+  auto subscription = g_node->create_subscription<std_msgs::msg::String>
       ("topic", topic_callback);
-  rclcpp::spin(node);
+  rclcpp::spin(g_node);
   rclcpp::shutdown();
   return 0;
 }

--- a/rclcpp/minimal_timer/lambda.cpp
+++ b/rclcpp/minimal_timer/lambda.cpp
@@ -27,7 +27,7 @@ public:
   MinimalTimer()
   : Node("minimal_timer")
   {
-    auto timer_callback = []() -> void { printf("Hello, world!\n"); };
+    auto timer_callback = [this]() -> void { RCLCPP_INFO(this->get_logger(), "Hello, world!") };
     timer_ = create_wall_timer(500ms, timer_callback);
   }
 

--- a/rclcpp/minimal_timer/member_function.cpp
+++ b/rclcpp/minimal_timer/member_function.cpp
@@ -32,7 +32,7 @@ public:
 private:
   void timer_callback()
   {
-    printf("Hello, world!\n");
+    RCLCPP_INFO(this->get_logger(), "Hello, world!")
   }
   rclcpp::TimerBase::SharedPtr timer_;
 };

--- a/rclpy/executors/examples_rclpy_executors/callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/callback_group.py
@@ -39,7 +39,7 @@ class DoubleTalker(Node):
         msg = String()
         msg.data = 'Hello World: {0}'.format(self.i)
         self.i += 1
-        print('Publishing: "{0}"'.format(msg.data))
+        self.get_logger().info('Publishing: "{0}"'.format(msg.data))
         self.pub.publish(msg)
 
 

--- a/rclpy/executors/examples_rclpy_executors/custom_callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_callback_group.py
@@ -92,7 +92,7 @@ class ThrottledTalker(Node):
         msg = String()
         msg.data = 'Hello World: {0}'.format(self.i)
         self.i += 1
-        print('Publishing: "{0}"'.format(msg.data))
+        self.get_logger().info('Publishing: "{0}"'.format(msg.data))
         self.pub.publish(msg)
 
 

--- a/rclpy/executors/examples_rclpy_executors/custom_executor.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_executor.py
@@ -30,7 +30,7 @@ class Estopper(Node):
         self.sub = self.create_subscription(String, 'estop', self.estop_callback)
 
     def estop_callback(self, msg):
-        print('I heard: [%s]' % msg.data)
+        self.get_logger().info('I heard: "%s"' % msg.data)
 
 
 class PriorityExecutor(Executor):

--- a/rclpy/executors/examples_rclpy_executors/listener.py
+++ b/rclpy/executors/examples_rclpy_executors/listener.py
@@ -32,7 +32,7 @@ class Listener(Node):
         self.sub = self.create_subscription(String, 'chatter', self.chatter_callback)
 
     def chatter_callback(self, msg):
-        print('I heard: [%s]' % msg.data)
+        self.get_logger().info('I heard: "%s"' % msg.data)
 
 
 def main(args=None):

--- a/rclpy/executors/examples_rclpy_executors/talker.py
+++ b/rclpy/executors/examples_rclpy_executors/talker.py
@@ -40,7 +40,7 @@ class Talker(Node):
         msg = String()
         msg.data = 'Hello World: {0}'.format(self.i)
         self.i += 1
-        print('Publishing: "{0}"'.format(msg.data))
+        self.get_logger().info('Publishing: "{0}"'.format(msg.data))
         self.pub.publish(msg)
 
 

--- a/rclpy/services/minimal_client/client.py
+++ b/rclpy/services/minimal_client/client.py
@@ -26,7 +26,7 @@ def main(args=None):
     req.a = 41
     req.b = 1
     while not cli.wait_for_service(timeout_sec=1.0):
-        print('service not available, waiting again...')
+        node.get_logger().info('service not available, waiting again...')
 
     cli.call(req)
     # when calling wait for future
@@ -35,7 +35,7 @@ def main(args=None):
     # TODO(mikaelarguedas) This is not the final API, and this does not scale
     # for multiple pending requests. This will change once an executor model is implemented
     # In the future the response will not be stored in cli.response
-    print(
+    node.get_logger().info(
         'Result of add_two_ints: for %d + %d = %d' %
         (req.a, req.b, cli.response.sum))
 

--- a/rclpy/services/minimal_client/client_async.py
+++ b/rclpy/services/minimal_client/client_async.py
@@ -28,7 +28,7 @@ def main(args=None):
     req.a = 41
     req.b = 1
     while not cli.wait_for_service(timeout_sec=1.0):
-        print('service not available, waiting again...')
+        node.get_logger().info('service not available, waiting again...')
 
     cli.call(req)
     while rclpy.ok():
@@ -36,7 +36,7 @@ def main(args=None):
         # for multiple pending requests. This will change once an executor model is implemented
         # In the future the response will not be stored in cli.response
         if cli.response is not None:
-            print(
+            node.get_logger().info(
                 'Result of add_two_ints: for %d + %d = %d' %
                 (req.a, req.b, cli.response.sum))
             break

--- a/rclpy/services/minimal_client/client_async_member_function.py
+++ b/rclpy/services/minimal_client/client_async_member_function.py
@@ -24,7 +24,7 @@ class MinimalClientAsync(Node):
         super().__init__('minimal_client_async')
         self.cli = self.create_client(AddTwoInts, 'add_two_ints')
         while not self.cli.wait_for_service(timeout_sec=1.0):
-            print('service not available, waiting again...')
+            self.get_logger().info('service not available, waiting again...')
         self.req = AddTwoInts.Request()
 
     def send_request(self):
@@ -44,7 +44,7 @@ def main(args=None):
         # for multiple pending requests. This will change once an executor model is implemented
         # In the future the response will not be stored in cli.response
         if minimal_client.cli.response is not None:
-            print(
+            minimal_client.get_logger().info(
                 'Result of add_two_ints: for %d + %d = %d' %
                 (minimal_client.req.a, minimal_client.req.b, minimal_client.cli.response.sum))
             break

--- a/rclpy/services/minimal_service/service.py
+++ b/rclpy/services/minimal_service/service.py
@@ -19,7 +19,8 @@ import rclpy
 
 def add_two_ints_callback(request, response):
     response.sum = request.a + request.b
-    print('Incoming request\na: %d b: %d' % (request.a, request.b))
+    rclpy.logging.get_logger('minimal_service').info(
+        'Incoming request\na: %d b: %d' % (request.a, request.b))
 
     return response
 

--- a/rclpy/services/minimal_service/service.py
+++ b/rclpy/services/minimal_service/service.py
@@ -16,28 +16,32 @@ from example_interfaces.srv import AddTwoInts
 
 import rclpy
 
+g_node = None
+
 
 def add_two_ints_callback(request, response):
+    global g_node
     response.sum = request.a + request.b
-    rclpy.logging.get_logger('minimal_service').info(
+    g_node.get_logger().info(
         'Incoming request\na: %d b: %d' % (request.a, request.b))
 
     return response
 
 
 def main(args=None):
+    global g_node
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_service')
+    g_node = rclpy.create_node('minimal_service')
 
-    srv = node.create_service(AddTwoInts, 'add_two_ints', add_two_ints_callback)
+    srv = g_node.create_service(AddTwoInts, 'add_two_ints', add_two_ints_callback)
     while rclpy.ok():
-        rclpy.spin_once(node)
+        rclpy.spin_once(g_node)
 
     # Destroy the service attached to the node explicitly
     # (optional - otherwise it will be done automatically
     # when the garbage collector destroys the node object)
-    node.destroy_service(srv)
+    g_node.destroy_service(srv)
     rclpy.shutdown()
 
 

--- a/rclpy/services/minimal_service/service_member_function.py
+++ b/rclpy/services/minimal_service/service_member_function.py
@@ -26,7 +26,7 @@ class MinimalService(Node):
 
     def add_two_ints_callback(self, request, response):
         response.sum = request.a + request.b
-        print('Incoming request\na: %d b: %d' % (request.a, request.b))
+        self.get_logger().info('Incoming request\na: %d b: %d' % (request.a, request.b))
 
         return response
 

--- a/rclpy/topics/minimal_publisher/publisher_local_function.py
+++ b/rclpy/topics/minimal_publisher/publisher_local_function.py
@@ -30,7 +30,7 @@ def main(args=None):
         nonlocal i
         msg.data = 'Hello World: %d' % i
         i += 1
-        print('Publishing: "%s"' % msg.data)
+        node.get_logger().info('Publishing: "%s"' % msg.data)
         publisher.publish(msg)
 
     timer_period = 0.5  # seconds

--- a/rclpy/topics/minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/publisher_member_function.py
@@ -31,7 +31,7 @@ class MinimalPublisher(Node):
         msg = String()
         msg.data = 'Hello World: %d' % self.i
         self.publisher_.publish(msg)
-        print('Publishing: "%s"' % msg.data)
+        self.get_logger().info('Publishing: "%s"' % msg.data)
         self.i += 1
 
 

--- a/rclpy/topics/minimal_publisher/publisher_old_school.py
+++ b/rclpy/topics/minimal_publisher/publisher_old_school.py
@@ -37,7 +37,7 @@ def main(args=None):
     while rclpy.ok():
         msg.data = 'Hello World: %d' % i
         i += 1
-        print('Publishing: "%s"' % msg.data)
+        node.get_logger().info('Publishing: "%s"' % msg.data)
         publisher.publish(msg)
         sleep(0.5)  # seconds
 

--- a/rclpy/topics/minimal_subscriber/subscriber_lambda.py
+++ b/rclpy/topics/minimal_subscriber/subscriber_lambda.py
@@ -23,7 +23,7 @@ def main(args=None):
     node = rclpy.create_node('minimal_subscriber')
 
     subscription = node.create_subscription(
-        String, 'topic', lambda msg: print('I heard: [%s]' % msg.data))
+        String, 'topic', lambda msg: node.get_logger().info('I heard: "%s"' % msg.data))
     subscription  # prevent unused variable warning
 
     rclpy.spin(node)

--- a/rclpy/topics/minimal_subscriber/subscriber_member_function.py
+++ b/rclpy/topics/minimal_subscriber/subscriber_member_function.py
@@ -29,7 +29,7 @@ class MinimalSubscriber(Node):
         self.subscription  # prevent unused variable warning
 
     def listener_callback(self, msg):
-        print('I heard: [%s]' % msg.data)
+        self.get_logger().info('I heard: "%s"' % msg.data)
 
 
 def main(args=None):

--- a/rclpy/topics/minimal_subscriber/subscriber_old_school.py
+++ b/rclpy/topics/minimal_subscriber/subscriber_old_school.py
@@ -16,27 +16,32 @@ import rclpy
 
 from std_msgs.msg import String
 
+g_node = None
+
 
 def chatter_callback(msg):
-    rclpy.logging.get_logger('minimal_subscriber').info(
+    global g_node
+    # rclpy.logging.get_logger('minimal_subscriber').info(
+    g_node.get_logger().info(
         'I heard: "%s"' % msg.data)
 
 
 def main(args=None):
+    global g_node
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_subscriber')
+    g_node = rclpy.create_node('minimal_subscriber')
 
-    subscription = node.create_subscription(String, 'topic', chatter_callback)
+    subscription = g_node.create_subscription(String, 'topic', chatter_callback)
     subscription  # prevent unused variable warning
 
     while rclpy.ok():
-        rclpy.spin_once(node)
+        rclpy.spin_once(g_node)
 
     # Destroy the node explicitly
     # (optional - otherwise it will be done automatically
     # when the garbage collector destroys the node object)
-    node.destroy_node()
+    g_node.destroy_node()
     rclpy.shutdown()
 
 

--- a/rclpy/topics/minimal_subscriber/subscriber_old_school.py
+++ b/rclpy/topics/minimal_subscriber/subscriber_old_school.py
@@ -18,7 +18,8 @@ from std_msgs.msg import String
 
 
 def chatter_callback(msg):
-    print('I heard: [%s]' % msg.data)
+    rclpy.logging.get_logger('minimal_subscriber').info(
+        'I heard: "%s"' % msg.data)
 
 
 def main(args=None):

--- a/rclpy/topics/minimal_subscriber/subscriber_old_school.py
+++ b/rclpy/topics/minimal_subscriber/subscriber_old_school.py
@@ -21,7 +21,6 @@ g_node = None
 
 def chatter_callback(msg):
     global g_node
-    # rclpy.logging.get_logger('minimal_subscriber').info(
     g_node.get_logger().info(
         'I heard: "%s"' % msg.data)
 


### PR DESCRIPTION
I also changed the message printing from `Publishing: [%s]` to `Publishing: '%s'` as 
`[INFO] [publisher_node]: Publisher: [Hello, world! 0]` was getting a bit full of `[` and harder to scope the user printed message.
In Python it prints  `Publishing: "%s"` but I can change it if we want the messages to be identical in both languages