### PR TITLE
Fix custom_executor 'tupple is not an iterator'

### DIFF
--- a/rclpy/executors/examples_rclpy_executors/custom_executor.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_executor.py
@@ -67,7 +67,7 @@ class PriorityExecutor(Executor):
         """
         # wait_for_ready_callbacks yields callbacks that are ready to be executed
         try:
-            handler, group, node = next(self.wait_for_ready_callbacks(timeout_sec=timeout_sec))
+            handler, group, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
         except StopIteration:
             pass
         else:


### PR DESCRIPTION
ros2/rclpy#159 changed `wait_for_ready_callbacks` to manage the generator internally and return just a tuple. This PR fixes the example.

CI linux only on `examples_rclpy_executors` since this is a leaf package with no tests besides linters
http://ci.ros2.org/job/ci_linux/3759/ (passed)

connects to ros2/examples#193

