### PR TITLE
Use std::chrono_literals only

### DIFF
--- a/rclcpp/minimal_composition/src/publisher_node.cpp
+++ b/rclcpp/minimal_composition/src/publisher_node.cpp
@@ -18,12 +18,14 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
+using namespace std::chrono_literals;
+
 PublisherNode::PublisherNode()
 : Node("publisher_node"), count_(0)
 {
   publisher_ = create_publisher<std_msgs::msg::String>("topic");
   timer_ = create_wall_timer(
-    std::chrono::milliseconds(500), std::bind(&PublisherNode::on_timer, this));
+    500ms, std::bind(&PublisherNode::on_timer, this));
 }
 
 void PublisherNode::on_timer()

--- a/rclcpp/minimal_composition/src/publisher_node.cpp
+++ b/rclcpp/minimal_composition/src/publisher_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+
 #include "minimal_composition/publisher_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"

--- a/rclcpp/minimal_composition/src/publisher_node.cpp
+++ b/rclcpp/minimal_composition/src/publisher_node.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <chrono>
-
 #include "minimal_composition/publisher_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"


### PR DESCRIPTION
All examples in `rclcpp` directory use `std::chrono_literals` except in `publisher_node.cpp`.
This PR changes to use `500ms` instead of `std::chrono::milliseconds(500)` using `std::chrono_literals` such as the other examples.