### PR TITLE
Change the not_composable example to destroy subscription first.

### DIFF
--- a/rclcpp/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/minimal_subscriber/not_composable.cpp
@@ -15,8 +15,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
-rclcpp::Node::SharedPtr g_node = nullptr;
-
 /* We do not recommend this style anymore, because composition of multiple
  * nodes in the same executable is not possible. Please see one of the subclass
  * examples for the "new" recommended styles. This example is only included
@@ -24,17 +22,19 @@ rclcpp::Node::SharedPtr g_node = nullptr;
 
 void topic_callback(const std_msgs::msg::String::SharedPtr msg)
 {
-  RCLCPP_INFO(g_node->get_logger(), "I heard: '%s'", msg->data.c_str())
+  RCLCPP_INFO(rclcpp::get_logger("minimal_subscriber"), "I heard: '%s'", msg->data.c_str())
 }
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  g_node = rclcpp::Node::make_shared("minimal_subscriber");
-  auto subscription = g_node->create_subscription<std_msgs::msg::String>
+  // TODO(clalancette): We can't currently make g_node a global because of
+  // https://github.com/eProsima/Fast-RTPS/issues/235 .  Once that is fixed
+  // we may want to add another example that uses global nodes.
+  auto node = rclcpp::Node::make_shared("minimal_subscriber");
+  auto subscription = node->create_subscription<std_msgs::msg::String>
       ("topic", topic_callback);
-  rclcpp::spin(g_node);
+  rclcpp::spin(node);
   rclcpp::shutdown();
-  g_node = nullptr;
   return 0;
 }


### PR DESCRIPTION
We are seeing the following message when hitting Ctrl-C
in the subscriber not_composable node:

[ERROR] [rclcpp]: Error in destruction of rcl subscription handle: the Node Handle was destructed too early. You will leak memory

The problem is that setting g_node to nullptr causes the
node destructor to be run before the subscriber is destructed.
Due to another bug, we can't just remove that assignment, so
instead we make it all locally scoped in main for now, which
works around the problem.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This worksaround https://github.com/ros2/examples/issues/209