### PR TITLE
Hack to test that hardcoded typesupports for actions works

### DIFF
--- a/rclcpp/minimal_client/CMakeLists.txt
+++ b/rclcpp/minimal_client/CMakeLists.txt
@@ -12,12 +12,19 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(example_interfaces REQUIRED)
+find_package(test_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(client_main main.cpp)
 ament_target_dependencies(client_main rclcpp example_interfaces)
 
+add_executable(client_main_action main_action.cpp)
+ament_target_dependencies(client_main_action rclcpp test_msgs)
+
 install(TARGETS client_main
+  DESTINATION lib/${PROJECT_NAME})
+
+install(TARGETS client_main_action
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/rclcpp/minimal_client/main_action.cpp
+++ b/rclcpp/minimal_client/main_action.cpp
@@ -1,0 +1,49 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <cinttypes>
+#include <memory>
+#include "test_msgs/action/fibonacci.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using Fibonacci_Goal = test_msgs::action::Fibonacci::GoalRequestService;
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("minimal_client");
+  auto client = node->create_client<Fibonacci_Goal>("add_two_ints");
+  while (!client->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.");
+      return 1;
+    }
+    RCLCPP_INFO(node->get_logger(), "waiting for service to appear...");
+  }
+  auto request = std::make_shared<Fibonacci_Goal::Request>();
+  request->order = 2;
+  auto result_future = client->async_send_request(request);
+  if (rclcpp::spin_until_future_complete(node, result_future) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node->get_logger(), "service call failed :(");
+    return 1;
+  }
+  auto result = result_future.get();
+  RCLCPP_INFO(node->get_logger(), "result of %" PRId32 " = %s",
+    request->order, (result->accepted ? "true" : "false"));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rclcpp/minimal_client/package.xml
+++ b/rclcpp/minimal_client/package.xml
@@ -10,6 +10,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>test_msgs</depend>
+
   <build_depend>rclcpp</build_depend>
   <build_depend>example_interfaces</build_depend>
 

--- a/rclcpp/minimal_service/CMakeLists.txt
+++ b/rclcpp/minimal_service/CMakeLists.txt
@@ -12,12 +12,19 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(example_interfaces REQUIRED)
+find_package(test_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(service_main main.cpp)
 ament_target_dependencies(service_main rclcpp example_interfaces)
 
+add_executable(service_main_action main_action.cpp)
+ament_target_dependencies(service_main_action rclcpp test_msgs)
+
 install(TARGETS service_main
+  DESTINATION lib/${PROJECT_NAME})
+
+install(TARGETS service_main_action
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/rclcpp/minimal_service/main_action.cpp
+++ b/rclcpp/minimal_service/main_action.cpp
@@ -1,0 +1,44 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <inttypes.h>
+#include <memory>
+#include "test_msgs/action/fibonacci.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using Fibonacci_Goal = test_msgs::action::Fibonacci::GoalRequestService;
+rclcpp::Node::SharedPtr g_node = nullptr;
+
+void handle_service(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<Fibonacci_Goal::Request> request,
+  const std::shared_ptr<Fibonacci_Goal::Response> response)
+{
+  (void)request_header;
+  RCLCPP_INFO(
+    g_node->get_logger(),
+    "request: %" PRId32, request->order);
+  response->accepted = request->order % 2;
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  g_node = rclcpp::Node::make_shared("minimal_service");
+  auto server = g_node->create_service<Fibonacci_Goal>("add_two_ints", handle_service);
+  rclcpp::spin(g_node);
+  rclcpp::shutdown();
+  g_node = nullptr;
+  return 0;
+}

--- a/rclcpp/minimal_service/package.xml
+++ b/rclcpp/minimal_service/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>test_msgs</depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>example_interfaces</build_depend>
 


### PR DESCRIPTION
This PR isn't intended to be merged. It has a service and client that have been modified to use the hardcoded typesupport for an action file. The purpose of this PR is to have something that can be run to confirm the hardcoded typesupport is working.

connects to ros2/rcl_interfaces#47