### PR TITLE
Avoid deprecated API's by providing history settings

### DIFF
--- a/rclcpp/minimal_action_client/member_functions.cpp
+++ b/rclcpp/minimal_action_client/member_functions.cpp
@@ -27,7 +27,7 @@ public:
   using Fibonacci = example_interfaces::action::Fibonacci;
   using GoalHandleFibonacci = rclcpp_action::ClientGoalHandle<Fibonacci>;
 
-  MinimalActionClient(const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions())
+  explicit MinimalActionClient(const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions())
   : Node("minimal_action_client", node_options), goal_done_(false)
   {
     this->client_ptr_ = rclcpp_action::create_client<Fibonacci>(
@@ -108,7 +108,7 @@ private:
   void result_callback(const GoalHandleFibonacci::WrappedResult & result)
   {
     this->goal_done_ = true;
-    switch(result.code) {
+    switch (result.code) {
       case rclcpp_action::ResultCode::SUCCEEDED:
         break;
       case rclcpp_action::ResultCode::ABORTED:

--- a/rclcpp/minimal_action_client/not_composable.cpp
+++ b/rclcpp/minimal_action_client/not_composable.cpp
@@ -66,7 +66,7 @@ int main(int argc, char ** argv)
 
   rclcpp_action::ClientGoalHandle<Fibonacci>::WrappedResult wrapped_result = result_future.get();
 
-  switch(wrapped_result.code) {
+  switch (wrapped_result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:
       break;
     case rclcpp_action::ResultCode::ABORTED:
@@ -81,8 +81,7 @@ int main(int argc, char ** argv)
   }
 
   RCLCPP_INFO(node->get_logger(), "result received");
-  for (auto number : wrapped_result.result->sequence)
-  {
+  for (auto number : wrapped_result.result->sequence) {
     RCLCPP_INFO(node->get_logger(), "%" PRId64, number);
   }
 

--- a/rclcpp/minimal_action_client/not_composable_with_cancel.cpp
+++ b/rclcpp/minimal_action_client/not_composable_with_cancel.cpp
@@ -61,8 +61,7 @@ int main(int argc, char ** argv)
     result_future,
     std::chrono::seconds(3));
 
-  if (rclcpp::executor::FutureReturnCode::TIMEOUT == wait_result)
-  {
+  if (rclcpp::executor::FutureReturnCode::TIMEOUT == wait_result) {
     RCLCPP_INFO(node->get_logger(), "canceling goal");
     // Cancel the goal since it is taking too long
     auto cancel_result_future = action_client->async_cancel_goal(goal_handle);
@@ -74,9 +73,7 @@ int main(int argc, char ** argv)
       return 1;
     }
     RCLCPP_INFO(node->get_logger(), "goal is being canceled");
-  }
-  else if (rclcpp::executor::FutureReturnCode::SUCCESS != wait_result)
-  {
+  } else if (rclcpp::executor::FutureReturnCode::SUCCESS != wait_result) {
     RCLCPP_ERROR(node->get_logger(), "failed to get result");
     rclcpp::shutdown();
     return 1;
@@ -91,7 +88,7 @@ int main(int argc, char ** argv)
   }
 
   rclcpp_action::ClientGoalHandle<Fibonacci>::WrappedResult wrapped_result = result_future.get();
-  switch(wrapped_result.code) {
+  switch (wrapped_result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:
       break;
     case rclcpp_action::ResultCode::ABORTED:

--- a/rclcpp/minimal_action_client/not_composable_with_feedback.cpp
+++ b/rclcpp/minimal_action_client/not_composable_with_feedback.cpp
@@ -80,7 +80,7 @@ int main(int argc, char ** argv)
 
   rclcpp_action::ClientGoalHandle<Fibonacci>::WrappedResult wrapped_result = result_future.get();
 
-  switch(wrapped_result.code) {
+  switch (wrapped_result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:
       break;
     case rclcpp_action::ResultCode::ABORTED:
@@ -95,8 +95,7 @@ int main(int argc, char ** argv)
   }
 
   RCLCPP_INFO(g_node->get_logger(), "result received");
-  for (auto number : wrapped_result.result->sequence)
-  {
+  for (auto number : wrapped_result.result->sequence) {
     RCLCPP_INFO(g_node->get_logger(), "%" PRId64, number);
   }
 

--- a/rclcpp/minimal_action_server/member_functions.cpp
+++ b/rclcpp/minimal_action_server/member_functions.cpp
@@ -25,8 +25,8 @@ public:
   using Fibonacci = example_interfaces::action::Fibonacci;
   using GoalHandleFibonacci = rclcpp_action::ServerGoalHandle<Fibonacci>;
 
-  MinimalActionServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
-    : Node("minimal_action_server", options)
+  explicit MinimalActionServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  : Node("minimal_action_server", options)
   {
     using namespace std::placeholders;
 
@@ -51,8 +51,7 @@ private:
     RCLCPP_INFO(this->get_logger(), "Received goal request with order %d", goal->order);
     (void)uuid;
     // Let's reject sequences that are over 9000
-    if (goal->order > 9000)
-    {
+    if (goal->order > 9000) {
       return rclcpp_action::GoalResponse::REJECT;
     }
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -72,16 +71,14 @@ private:
     rclcpp::Rate loop_rate(1);
     const auto goal = goal_handle->get_goal();
     auto feedback = std::make_shared<Fibonacci::Feedback>();
-    auto& sequence = feedback->sequence;
+    auto & sequence = feedback->sequence;
     sequence.push_back(0);
     sequence.push_back(1);
     auto result = std::make_shared<Fibonacci::Result>();
 
-    for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i)
-    {
+    for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i) {
       // Check if there is a cancel request
-      if (goal_handle->is_canceling())
-      {
+      if (goal_handle->is_canceling()) {
         result->sequence = sequence;
         goal_handle->canceled(result);
         RCLCPP_INFO(this->get_logger(), "Goal Canceled");

--- a/rclcpp/minimal_action_server/not_composable.cpp
+++ b/rclcpp/minimal_action_server/not_composable.cpp
@@ -28,8 +28,7 @@ rclcpp_action::GoalResponse handle_goal(
   RCLCPP_INFO(rclcpp::get_logger("server"), "Got goal request with order %d", goal->order);
   (void)uuid;
   // Let's reject sequences that are over 9000
-  if (goal->order > 9000)
-  {
+  if (goal->order > 9000) {
     return rclcpp_action::GoalResponse::REJECT;
   }
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -50,16 +49,14 @@ void execute(
   rclcpp::Rate loop_rate(1);
   const auto goal = goal_handle->get_goal();
   auto feedback = std::make_shared<Fibonacci::Feedback>();
-  auto& sequence = feedback->sequence;
+  auto & sequence = feedback->sequence;
   sequence.push_back(0);
   sequence.push_back(1);
   auto result = std::make_shared<Fibonacci::Result>();
 
-  for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i)
-  {
+  for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i) {
     // Check if there is a cancel request
-    if (goal_handle->is_canceling())
-    {
+    if (goal_handle->is_canceling()) {
       result->sequence = sequence;
       goal_handle->canceled(result);
       RCLCPP_INFO(rclcpp::get_logger("server"), "Goal Canceled");

--- a/rclcpp/minimal_composition/src/publisher_node.cpp
+++ b/rclcpp/minimal_composition/src/publisher_node.cpp
@@ -23,7 +23,7 @@ using namespace std::chrono_literals;
 PublisherNode::PublisherNode(rclcpp::NodeOptions options)
 : Node("publisher_node", options), count_(0)
 {
-  publisher_ = create_publisher<std_msgs::msg::String>("topic");
+  publisher_ = create_publisher<std_msgs::msg::String>("topic", 10);
   timer_ = create_wall_timer(
     500ms, std::bind(&PublisherNode::on_timer, this));
 }

--- a/rclcpp/minimal_composition/src/subscriber_node.cpp
+++ b/rclcpp/minimal_composition/src/subscriber_node.cpp
@@ -30,4 +30,3 @@ SubscriberNode::SubscriberNode(rclcpp::NodeOptions options)
 #include "rclcpp_components/register_node_macro.hpp"
 
 RCLCPP_COMPONENTS_REGISTER_NODE(SubscriberNode)
-

--- a/rclcpp/minimal_composition/src/subscriber_node.cpp
+++ b/rclcpp/minimal_composition/src/subscriber_node.cpp
@@ -21,6 +21,7 @@ SubscriberNode::SubscriberNode(rclcpp::NodeOptions options)
 {
   subscription_ = create_subscription<std_msgs::msg::String>(
     "topic",
+    10,
     [this](std_msgs::msg::String::UniquePtr msg) {
       RCLCPP_INFO(this->get_logger(), "Subscriber: '%s'", msg->data.c_str());
     });

--- a/rclcpp/minimal_publisher/lambda.cpp
+++ b/rclcpp/minimal_publisher/lambda.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 

--- a/rclcpp/minimal_publisher/lambda.cpp
+++ b/rclcpp/minimal_publisher/lambda.cpp
@@ -28,7 +28,7 @@ public:
   MinimalPublisher()
   : Node("minimal_publisher"), count_(0)
   {
-    publisher_ = this->create_publisher<std_msgs::msg::String>("topic");
+    publisher_ = this->create_publisher<std_msgs::msg::String>("topic", 10);
     auto timer_callback =
       [this]() -> void {
         auto message = std_msgs::msg::String();

--- a/rclcpp/minimal_publisher/member_function.cpp
+++ b/rclcpp/minimal_publisher/member_function.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 

--- a/rclcpp/minimal_publisher/member_function.cpp
+++ b/rclcpp/minimal_publisher/member_function.cpp
@@ -27,7 +27,7 @@ public:
   MinimalPublisher()
   : Node("minimal_publisher"), count_(0)
   {
-    publisher_ = this->create_publisher<std_msgs::msg::String>("topic");
+    publisher_ = this->create_publisher<std_msgs::msg::String>("topic", 10);
     timer_ = this->create_wall_timer(
       500ms, std::bind(&MinimalPublisher::timer_callback, this));
   }

--- a/rclcpp/minimal_publisher/not_composable.cpp
+++ b/rclcpp/minimal_publisher/not_composable.cpp
@@ -28,7 +28,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("minimal_publisher");
-  auto publisher = node->create_publisher<std_msgs::msg::String>("topic");
+  auto publisher = node->create_publisher<std_msgs::msg::String>("topic", 10);
   std_msgs::msg::String message;
   auto publish_count = 0;
   rclcpp::WallRate loop_rate(500ms);

--- a/rclcpp/minimal_subscriber/lambda.cpp
+++ b/rclcpp/minimal_subscriber/lambda.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <iostream>
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
@@ -26,8 +28,8 @@ public:
       "topic",
       10,
       [this](std_msgs::msg::String::UniquePtr msg) {
-      RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
-    });
+        RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+      });
   }
 
 private:

--- a/rclcpp/minimal_subscriber/lambda.cpp
+++ b/rclcpp/minimal_subscriber/lambda.cpp
@@ -24,6 +24,7 @@ public:
   {
     subscription_ = this->create_subscription<std_msgs::msg::String>(
       "topic",
+      10,
       [this](std_msgs::msg::String::UniquePtr msg) {
       RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
     });

--- a/rclcpp/minimal_subscriber/member_function.cpp
+++ b/rclcpp/minimal_subscriber/member_function.cpp
@@ -23,7 +23,7 @@ public:
   : Node("minimal_subscriber")
   {
     subscription_ = this->create_subscription<std_msgs::msg::String>(
-      "topic", std::bind(&MinimalSubscriber::topic_callback, this, _1));
+      "topic", 10, std::bind(&MinimalSubscriber::topic_callback, this, _1));
   }
 
 private:

--- a/rclcpp/minimal_subscriber/member_function.cpp
+++ b/rclcpp/minimal_subscriber/member_function.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 using std::placeholders::_1;

--- a/rclcpp/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/minimal_subscriber/not_composable.cpp
@@ -31,8 +31,8 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   g_node = rclcpp::Node::make_shared("minimal_subscriber");
-  auto subscription = g_node->create_subscription<std_msgs::msg::String>
-      ("topic", topic_callback);
+  auto subscription =
+    g_node->create_subscription<std_msgs::msg::String>("topic", 10, topic_callback);
   rclcpp::spin(g_node);
   rclcpp::shutdown();
   // TODO(clalancette): It would be better to remove both of these nullptr

--- a/rclcpp/minimal_timer/lambda.cpp
+++ b/rclcpp/minimal_timer/lambda.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 
 using namespace std::chrono_literals;
@@ -28,7 +30,7 @@ public:
   MinimalTimer()
   : Node("minimal_timer")
   {
-    auto timer_callback = [this]() -> void { RCLCPP_INFO(this->get_logger(), "Hello, world!"); };
+    auto timer_callback = [this]() -> void {RCLCPP_INFO(this->get_logger(), "Hello, world!");};
     timer_ = create_wall_timer(500ms, timer_callback);
   }
 

--- a/rclcpp/minimal_timer/member_function.cpp
+++ b/rclcpp/minimal_timer/member_function.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 
 using namespace std::chrono_literals;


### PR DESCRIPTION
I also ran `ament_uncrustify` and `ament_cpplint` over these, since it seems it's not run continually.

Connects to ros2/rclcpp#713