### PR TITLE
Use action client get result method

### DIFF
--- a/rclcpp/minimal_action_client/not_composable.cpp
+++ b/rclcpp/minimal_action_client/not_composable.cpp
@@ -54,7 +54,7 @@ int main(int argc, char ** argv)
   }
 
   // Wait for the server to be done with the goal
-  auto result_future = goal_handle->async_result();
+  auto result_future = action_client->async_get_result(goal_handle);
 
   RCLCPP_INFO(node->get_logger(), "Waiting for result");
   if (rclcpp::spin_until_future_complete(node, result_future) !=

--- a/rclcpp/minimal_action_client/not_composable_with_cancel.cpp
+++ b/rclcpp/minimal_action_client/not_composable_with_cancel.cpp
@@ -54,7 +54,7 @@ int main(int argc, char ** argv)
   }
 
   // Wait for the server to be done with the goal
-  auto result_future = goal_handle->async_result();
+  auto result_future = action_client->async_get_result(goal_handle);
 
   auto wait_result = rclcpp::spin_until_future_complete(
     node,

--- a/rclcpp/minimal_action_client/not_composable_with_feedback.cpp
+++ b/rclcpp/minimal_action_client/not_composable_with_feedback.cpp
@@ -68,7 +68,7 @@ int main(int argc, char ** argv)
   }
 
   // Wait for the server to be done with the goal
-  auto result_future = goal_handle->async_result();
+  auto result_future = action_client->async_get_result(goal_handle);
 
   RCLCPP_INFO(g_node->get_logger(), "Waiting for result");
   if (rclcpp::spin_until_future_complete(g_node, result_future) !=


### PR DESCRIPTION
Since a result callback is not provided when sending the goal, the goal handle is not "result aware"
and calling the action client method will make it so.

The behaviour was changed in https://github.com/ros2/rclcpp/pull/701.

Fixes #243 