### PR TITLE
make member function const

### DIFF
--- a/rclcpp/minimal_subscriber/member_function.cpp
+++ b/rclcpp/minimal_subscriber/member_function.cpp
@@ -29,7 +29,7 @@ public:
   }
 
 private:
-  void topic_callback(const std_msgs::msg::String::SharedPtr msg)
+  void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
   {
     RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
   }


### PR DESCRIPTION
Given the conversation in https://github.com/ros2/rclcpp/pull/763 I think it makes sense to have the member function declared as `const`.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7372)](http://ci.ros2.org/job/ci_linux/7372/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3530)](http://ci.ros2.org/job/ci_linux-aarch64/3530/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6047)](http://ci.ros2.org/job/ci_osx/6047/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7199)](http://ci.ros2.org/job/ci_windows/7199/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>