### PR TITLE
[Backport] Make member function const

### DIFF
--- a/rclcpp/minimal_subscriber/member_function.cpp
+++ b/rclcpp/minimal_subscriber/member_function.cpp
@@ -29,7 +29,7 @@ public:
   }
 
 private:
-  void topic_callback(const std_msgs::msg::String::SharedPtr msg)
+  void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
   {
     RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
   }


### PR DESCRIPTION
Backports #247 to Dashing, is a repeat of #249 targeting the `dashing` branch.