### PR TITLE
Fix client_cancel example

### DIFF
--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_cancel.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_cancel.py
@@ -19,7 +19,6 @@ import rclpy
 from rclpy.action import ActionClient
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
-from rclpy.timer import WallTimer
 
 
 class MinimalActionClient(Node):


### PR DESCRIPTION
Precisely what the title says. Removes unused import of a nonexistent class.