### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/rclcpp/minimal_client/main.cpp
+++ b/rclcpp/minimal_client/main.cpp
@@ -43,7 +43,8 @@ int main(int argc, char * argv[])
     return 1;
   }
   auto result = result_future.get();
-  RCLCPP_INFO(node->get_logger(), "result of %" PRId64 " + %" PRId64 " = %" PRId64,
+  RCLCPP_INFO(
+    node->get_logger(), "result of %" PRId64 " + %" PRId64 " = %" PRId64,
     request->a, request->b, result->sum);
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.