### PR TITLE
Fixed examples_rclcpp_minimal_action_client sequence type

### DIFF
--- a/rclcpp/actions/minimal_action_client/member_functions.cpp
+++ b/rclcpp/actions/minimal_action_client/member_functions.cpp
@@ -101,7 +101,7 @@ private:
   {
     RCLCPP_INFO(
       this->get_logger(),
-      "Next number in sequence received: %" PRId64,
+      "Next number in sequence received: %" PRId32,
       feedback->sequence.back());
   }
 
@@ -124,7 +124,7 @@ private:
 
     RCLCPP_INFO(this->get_logger(), "Result received");
     for (auto number : result.result->sequence) {
-      RCLCPP_INFO(this->get_logger(), "%" PRId64, number);
+      RCLCPP_INFO(this->get_logger(), "%" PRId32, number);
     }
   }
 };  // class MinimalActionClient

--- a/rclcpp/actions/minimal_action_client/not_composable.cpp
+++ b/rclcpp/actions/minimal_action_client/not_composable.cpp
@@ -82,7 +82,7 @@ int main(int argc, char ** argv)
 
   RCLCPP_INFO(node->get_logger(), "result received");
   for (auto number : wrapped_result.result->sequence) {
-    RCLCPP_INFO(node->get_logger(), "%" PRId64, number);
+    RCLCPP_INFO(node->get_logger(), "%" PRId32, number);
   }
 
   rclcpp::shutdown();

--- a/rclcpp/actions/minimal_action_client/not_composable_with_feedback.cpp
+++ b/rclcpp/actions/minimal_action_client/not_composable_with_feedback.cpp
@@ -29,7 +29,7 @@ void feedback_callback(
 {
   RCLCPP_INFO(
     g_node->get_logger(),
-    "Next number in sequence received: %" PRId64,
+    "Next number in sequence received: %" PRId32,
     feedback->sequence.back());
 }
 
@@ -96,7 +96,7 @@ int main(int argc, char ** argv)
 
   RCLCPP_INFO(g_node->get_logger(), "result received");
   for (auto number : wrapped_result.result->sequence) {
-    RCLCPP_INFO(g_node->get_logger(), "%" PRId64, number);
+    RCLCPP_INFO(g_node->get_logger(), "%" PRId32, number);
   }
 
   action_client.reset();


### PR DESCRIPTION
[Fibonacci action](https://github.com/ros2/example_interfaces/blob/master/action/Fibonacci.action) interface use `int32` for the sequence. However in the code this is printed as `int64`.

Signed-off-by: ahcorde <ahcorde@gmail.com>