### PR TITLE
Initialized count in examples_rclcpp_multithreaded_executor

### DIFF
--- a/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
+++ b/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
@@ -39,7 +39,7 @@ class PublisherNode : public rclcpp::Node
 {
 public:
   PublisherNode()
-  : Node("PublisherNode")
+  : Node("PublisherNode"), count_(0)
   {
     publisher_ = this->create_publisher<std_msgs::msg::String>("topic", 10);
     auto timer_callback =


### PR DESCRIPTION
Initialized `count` variable in `examples_rclcpp_multithreaded_executor`. In Linux seems to work properly but on Windows the generate a random number each time that the executable is launched.

Signed-off-by: ahcorde <ahcorde@gmail.com>