### PR TITLE
Add pytest.ini to silence warnings when running locally.

### DIFF
--- a/rclpy/pytest.ini
+++ b/rclpy/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #278 