### PR TITLE
Remove bare exception catching to fix Flake8 failure

### DIFF
--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py
@@ -31,14 +31,10 @@ def main(args=None):
     future = cli.call_async(req)
     rclpy.spin_until_future_complete(node, future)
 
-    try:
-        result = future.result()
-    except Exception as e:
-        node.get_logger().info('Service call failed %r' % (e,))
-    else:
-        node.get_logger().info(
-            'Result of add_two_ints: for %d + %d = %d' %
-            (req.a, req.b, result.sum))
+    result = future.result()
+    node.get_logger().info(
+        'Result of add_two_ints: for %d + %d = %d' %
+        (req.a, req.b, result.sum))
 
     node.destroy_node()
     rclpy.shutdown()

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async.py
@@ -34,14 +34,10 @@ def main(args=None):
     while rclpy.ok():
         rclpy.spin_once(node)
         if future.done():
-            try:
-                result = future.result()
-            except Exception as e:
-                node.get_logger().info('Service call failed %r' % (e,))
-            else:
-                node.get_logger().info(
-                    'Result of add_two_ints: for %d + %d = %d' %
-                    (req.a, req.b, result.sum))
+            result = future.result()
+            node.get_logger().info(
+                'Result of add_two_ints: for %d + %d = %d' %
+                (req.a, req.b, result.sum))
             break
 
     node.destroy_node()

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py
@@ -37,14 +37,10 @@ def main(args=None):
             req.a = 41
             req.b = 1
             future = cli.call_async(req)
-            try:
-                result = await future
-            except Exception as e:
-                node.get_logger().info('Service call failed %r' % (e,))
-            else:
-                node.get_logger().info(
-                    'Result of add_two_ints: for %d + %d = %d' %
-                    (req.a, req.b, result.sum))
+            result = await future
+            node.get_logger().info(
+                'Result of add_two_ints: for %d + %d = %d' %
+                (req.a, req.b, result.sum))
         finally:
             did_get_result = True
 

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_member_function.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_member_function.py
@@ -42,15 +42,10 @@ def main(args=None):
     while rclpy.ok():
         rclpy.spin_once(minimal_client)
         if minimal_client.future.done():
-            try:
-                response = minimal_client.future.result()
-            except Exception as e:
-                minimal_client.get_logger().info(
-                    'Service call failed %r' % (e,))
-            else:
-                minimal_client.get_logger().info(
-                    'Result of add_two_ints: for %d + %d = %d' %
-                    (minimal_client.req.a, minimal_client.req.b, response.sum))
+            response = minimal_client.future.result()
+            minimal_client.get_logger().info(
+                'Result of add_two_ints: for %d + %d = %d' %
+                (minimal_client.req.a, minimal_client.req.b, response.sum))
             break
 
     minimal_client.destroy_node()


### PR DESCRIPTION
While reviewing CI results I noticed these new flake8 failures on master:

https://ci.ros2.org/job/ci_linux/13378/#showFailuresLink

It complains about catching `Exception`, and wants specific exceptions to be caught instead. I reviewed the `rclpy` code handling the client futures, and discovered that there's actually no code setting exceptions on them currently, so the `try`/`except` blocks don't actually do anything. This PR removes them from the examples to resolve the flake8 failures.


@azeey FYI