### PR TITLE
Fix clang warnings about type mismatches.

### DIFF
--- a/rclcpp/executors/cbg_executor/src/ping.cpp
+++ b/rclcpp/executors/cbg_executor/src/ping.cpp
@@ -71,8 +71,8 @@ int main(int argc, char * argv[])
   }
 
   const std::chrono::seconds EXPERIMENT_DURATION = 10s;
-  RCLCPP_INFO(
-    logger, "Running experiment from now on for %" PRId64 "s ...", EXPERIMENT_DURATION.count());
+  RCLCPP_INFO_STREAM(
+    logger, "Running experiment from now on for " << EXPERIMENT_DURATION.count() << " seconds ...");
   std::this_thread::sleep_for(EXPERIMENT_DURATION);
 
   // ... and stop the experiment.

--- a/rclcpp/executors/cbg_executor/src/ping_pong.cpp
+++ b/rclcpp/executors/cbg_executor/src/ping_pong.cpp
@@ -96,8 +96,8 @@ int main(int argc, char * argv[])
   nanoseconds low_prio_thread_begin = get_thread_time(low_prio_thread);
 
   const std::chrono::seconds EXPERIMENT_DURATION = 10s;
-  RCLCPP_INFO(
-    logger, "Running experiment from now on for %" PRId64 "s ...", EXPERIMENT_DURATION.count());
+  RCLCPP_INFO_STREAM(
+    logger, "Running experiment from now on for " << EXPERIMENT_DURATION.count() << " seconds ...");
   std::this_thread::sleep_for(EXPERIMENT_DURATION);
 
   // Get end CPU time of each thread ...

--- a/rclcpp/executors/cbg_executor/src/pong.cpp
+++ b/rclcpp/executors/cbg_executor/src/pong.cpp
@@ -90,8 +90,8 @@ int main(int argc, char * argv[])
   nanoseconds low_prio_thread_begin = get_thread_time(low_prio_thread);
 
   const std::chrono::seconds EXPERIMENT_DURATION = 10s;
-  RCLCPP_INFO(
-    logger, "Running experiment from now on for %" PRId64 "s ...", EXPERIMENT_DURATION.count());
+  RCLCPP_INFO_STREAM(
+    logger, "Running experiment from now on for " << EXPERIMENT_DURATION.count() << " seconds ...");
   std::this_thread::sleep_for(EXPERIMENT_DURATION);
 
   // Get end CPU time of each thread ...


### PR DESCRIPTION
The clang-on-linux job is still complaining about the types
of PRId64 vs. std::chrono::seconds.count().  Give up and
switch to streams here, which should solve the issue.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>