### PR TITLE
Use underscores instead of dashes in setup.cfg

### DIFF
--- a/rclpy/actions/minimal_action_client/setup.cfg
+++ b/rclpy/actions/minimal_action_client/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_minimal_action_client
+script_dir=$base/lib/examples_rclpy_minimal_action_client
 [install]
-install-scripts=$base/lib/examples_rclpy_minimal_action_client
+install_scripts=$base/lib/examples_rclpy_minimal_action_client

--- a/rclpy/actions/minimal_action_server/setup.cfg
+++ b/rclpy/actions/minimal_action_server/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_minimal_action_server
+script_dir=$base/lib/examples_rclpy_minimal_action_server
 [install]
-install-scripts=$base/lib/examples_rclpy_minimal_action_server
+install_scripts=$base/lib/examples_rclpy_minimal_action_server

--- a/rclpy/executors/setup.cfg
+++ b/rclpy/executors/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_executors
+script_dir=$base/lib/examples_rclpy_executors
 [install]
-install-scripts=$base/lib/examples_rclpy_executors
+install_scripts=$base/lib/examples_rclpy_executors

--- a/rclpy/guard_conditions/setup.cfg
+++ b/rclpy/guard_conditions/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_guard_conditions
+script_dir=$base/lib/examples_rclpy_guard_conditions
 [install]
-install-scripts=$base/lib/examples_rclpy_guard_conditions
+install_scripts=$base/lib/examples_rclpy_guard_conditions

--- a/rclpy/services/minimal_client/setup.cfg
+++ b/rclpy/services/minimal_client/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_minimal_client
+script_dir=$base/lib/examples_rclpy_minimal_client
 [install]
-install-scripts=$base/lib/examples_rclpy_minimal_client
+install_scripts=$base/lib/examples_rclpy_minimal_client

--- a/rclpy/services/minimal_service/setup.cfg
+++ b/rclpy/services/minimal_service/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_minimal_service
+script_dir=$base/lib/examples_rclpy_minimal_service
 [install]
-install-scripts=$base/lib/examples_rclpy_minimal_service
+install_scripts=$base/lib/examples_rclpy_minimal_service

--- a/rclpy/topics/minimal_publisher/setup.cfg
+++ b/rclpy/topics/minimal_publisher/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_minimal_publisher
+script_dir=$base/lib/examples_rclpy_minimal_publisher
 [install]
-install-scripts=$base/lib/examples_rclpy_minimal_publisher
+install_scripts=$base/lib/examples_rclpy_minimal_publisher

--- a/rclpy/topics/minimal_subscriber/setup.cfg
+++ b/rclpy/topics/minimal_subscriber/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_minimal_subscriber
+script_dir=$base/lib/examples_rclpy_minimal_subscriber
 [install]
-install-scripts=$base/lib/examples_rclpy_minimal_subscriber
+install_scripts=$base/lib/examples_rclpy_minimal_subscriber

--- a/rclpy/topics/pointcloud_publisher/setup.cfg
+++ b/rclpy/topics/pointcloud_publisher/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_rclpy_pointcloud_publisher
+script_dir=$base/lib/examples_rclpy_pointcloud_publisher
 [install]
-install-scripts=$base/lib/examples_rclpy_pointcloud_publisher
+install_scripts=$base/lib/examples_rclpy_pointcloud_publisher


### PR DESCRIPTION
Fixes https://ci.ros2.org/view/nightly/job/nightly_linux_release/1890/consoleFull#console-section-485 and similar


```
Starting >>> examples_rclpy_minimal_publisher
03:48:02 /home/jenkins-agent/workspace/nightly_linux_release/venv/lib/python3.8/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
03:48:02   warnings.warn(
03:48:02 /home/jenkins-agent/workspace/nightly_linux_release/venv/lib/python3.8/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
03:48:02   warnings.warn(
03:48:03 /home/jenkins-agent/workspace/nightly_linux_release/venv/lib/python3.8/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
03:48:03   warnings.warn(
03:48:03 /home/jenkins-agent/workspace/nightly_linux_release/venv/lib/python3.8/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
03:48:03   warnings.warn(
03:48:03 
```