### PR TITLE
Remove use of get_callback_groups().

### DIFF
--- a/rclcpp/executors/cbg_executor/include/examples_rclcpp_cbg_executor/pong_node.hpp
+++ b/rclcpp/executors/cbg_executor/include/examples_rclcpp_cbg_executor/pong_node.hpp
@@ -37,6 +37,8 @@ public:
   rclcpp::CallbackGroup::SharedPtr get_low_prio_callback_group();
 
 private:
+  rclcpp::CallbackGroup::SharedPtr low_prio_callback_group_;
+
   rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr high_ping_subscription_;
   rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr high_pong_publisher_;
   void high_ping_received(const std_msgs::msg::Int32::SharedPtr msg);


### PR DESCRIPTION
This is not thread-safe, and we can do exactly the same
thing by getting the default callback group and storing
our custom callback group within the class.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Goes along with https://github.com/ros2/rclcpp/pull/1723