### PR TITLE
Reverted WaitForTopics utility usage

### DIFF
--- a/launch_testing/launch_testing_examples/launch_testing_examples/check_msgs_launch_test.py
+++ b/launch_testing/launch_testing_examples/launch_testing_examples/check_msgs_launch_test.py
@@ -45,7 +45,7 @@ def generate_test_description():
 
 class TestFixture(unittest.TestCase):
 
-    def test_check_if_msgs_published(self, proc_output):
+    def test_check_if_msgs_published(self):
         with WaitForTopics([('chatter', String)], timeout=5.0):
             print('Topic received messages !')
 


### PR DESCRIPTION
Removed usage of the ``WaitForTopics`` utiity that was reverted in https://github.com/ros2/launch_ros/pull/276

Signed-off-by: Aditya Pande <aditya050995@gmail.com>