### PR TITLE
Use `const&` signature for read-only sub callbacks

### DIFF
--- a/rclcpp/topics/minimal_subscriber/member_function.cpp
+++ b/rclcpp/topics/minimal_subscriber/member_function.cpp
@@ -31,9 +31,9 @@ public:
   }
 
 private:
-  void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
+  void topic_callback(const std_msgs::msg::String & msg) const
   {
-    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg.data.c_str());
   }
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
 };

--- a/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
+++ b/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
@@ -36,7 +36,7 @@ public:
     // configure the topic name (default '/statistics')
     // options.topic_stats_options.publish_topic = "/topic_statistics"
 
-    auto callback = [this](std_msgs::msg::String::ConstSharedPtr msg) {
+    auto callback = [this](const std_msgs::msg::String & msg) {
         this->topic_callback(msg);
       };
 
@@ -45,9 +45,9 @@ public:
   }
 
 private:
-  void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
+  void topic_callback(const std_msgs::msg::String & msg) const
   {
-    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg.data.c_str());
   }
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
 };

--- a/rclcpp/topics/minimal_subscriber/member_function_with_unique_network_flow_endpoints.cpp
+++ b/rclcpp/topics/minimal_subscriber/member_function_with_unique_network_flow_endpoints.cpp
@@ -79,13 +79,13 @@ public:
   }
 
 private:
-  void topic_1_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
+  void topic_1_callback(const std_msgs::msg::String & msg) const
   {
-    RCLCPP_INFO(this->get_logger(), "Topic 1 news: '%s'", msg->data.c_str());
+    RCLCPP_INFO(this->get_logger(), "Topic 1 news: '%s'", msg.data.c_str());
   }
-  void topic_2_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
+  void topic_2_callback(const std_msgs::msg::String & msg) const
   {
-    RCLCPP_INFO(this->get_logger(), "Topic 2 news: '%s'", msg->data.c_str());
+    RCLCPP_INFO(this->get_logger(), "Topic 2 news: '%s'", msg.data.c_str());
   }
   /// Print network flow endpoints in JSON-like format
   void print_network_flow_endpoints(

--- a/rclcpp/topics/minimal_subscriber/not_composable.cpp
+++ b/rclcpp/topics/minimal_subscriber/not_composable.cpp
@@ -22,9 +22,9 @@ rclcpp::Node::SharedPtr g_node = nullptr;
  * examples for the "new" recommended styles. This example is only included
  * for completeness because it is similar to "classic" standalone ROS nodes. */
 
-void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg)
+void topic_callback(const std_msgs::msg::String & msg)
 {
-  RCLCPP_INFO(g_node->get_logger(), "I heard: '%s'", msg->data.c_str());
+  RCLCPP_INFO(g_node->get_logger(), "I heard: '%s'", msg.data.c_str());
 }
 
 int main(int argc, char * argv[])


### PR DESCRIPTION
The constant reference message signatures should be preferred over the
shared pointer to constant message signatures for read-only subscriber
callbacks, as discussed in https://github.com/ros2/rclcpp/pull/1598.

As such, it makes sense to migrate to said signatures in the examples.

Note that this should be backported to Galactic _only_.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>