### PR TITLE
Windows build errors : static link wait_set_subscriber_library

### DIFF
--- a/rclcpp/topics/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/topics/minimal_subscriber/CMakeLists.txt
@@ -36,7 +36,7 @@ ament_target_dependencies(subscriber_not_composable rclcpp std_msgs)
 add_executable(subscriber_content_filtering content_filtering.cpp)
 ament_target_dependencies(subscriber_content_filtering rclcpp std_msgs)
 
-add_library(wait_set_subscriber_library SHARED
+add_library(wait_set_subscriber_library STATIC
     wait_set_subscriber.cpp
     static_wait_set_subscriber.cpp
     time_triggered_wait_set_subscriber.cpp)


### PR DESCRIPTION
This PR fixes the problem mentioned here : https://github.com/ros2/examples/issues/344
Windows builds are not able to find ``wait_set_subscriber_library.lib``

Signed-off-by: Aditya <aditya050995@gmail.com>