### PR TITLE
increase the timeout for window platform to avoid flaky test

### DIFF
--- a/launch_testing/launch_testing_examples/launch_testing_examples/check_multiple_nodes_launch_test.py
+++ b/launch_testing/launch_testing_examples/launch_testing_examples/check_multiple_nodes_launch_test.py
@@ -53,7 +53,7 @@ class CheckMultipleNodesLaunched(unittest.TestCase):
     def test_nodes_successful(self, node_list):
         """Check if all the nodes were launched correctly."""
         # Method 1
-        wait_for_nodes_1 = WaitForNodes(node_list, timeout=5.0)
+        wait_for_nodes_1 = WaitForNodes(node_list, timeout=10.0)
         assert wait_for_nodes_1.wait()
         assert wait_for_nodes_1.get_nodes_not_found() == set()
         wait_for_nodes_1.shutdown()

--- a/launch_testing/launch_testing_examples/launch_testing_examples/check_multiple_nodes_launch_test.py
+++ b/launch_testing/launch_testing_examples/launch_testing_examples/check_multiple_nodes_launch_test.py
@@ -59,7 +59,7 @@ class CheckMultipleNodesLaunched(unittest.TestCase):
         wait_for_nodes_1.shutdown()
 
         # Method 2
-        with WaitForNodes(node_list, timeout=5.0) as wait_for_nodes_2:
+        with WaitForNodes(node_list, timeout=10.0) as wait_for_nodes_2:
             print('All nodes were found !')
             assert wait_for_nodes_2.get_nodes_not_found() == set()
 
@@ -68,14 +68,14 @@ class CheckMultipleNodesLaunched(unittest.TestCase):
         invalid_node_list = node_list + ['invalid_node']
 
         # Method 1
-        wait_for_nodes_1 = WaitForNodes(invalid_node_list, timeout=5.0)
+        wait_for_nodes_1 = WaitForNodes(invalid_node_list, timeout=10.0)
         assert not wait_for_nodes_1.wait()
         assert wait_for_nodes_1.get_nodes_not_found() == {'invalid_node'}
         wait_for_nodes_1.shutdown()
 
         # Method 2
         with pytest.raises(RuntimeError):
-            with WaitForNodes(invalid_node_list, timeout=5.0):
+            with WaitForNodes(invalid_node_list, timeout=10.0):
                 pass
 
 


### PR DESCRIPTION
A flaky test about `launch_testing_examples\check_multiple_nodes_launch_test.py` is always reported while running CI.

After comparing the success and failure cases between https://ci.ros2.org/job/ci_windows/18721/consoleFull and https://ci.ros2.org/job/ci_windows/18738/consoleFull, I suspect that the timeout of waiting on the Window platform might not be enough.

Successful log in https://ci.ros2.org/job/ci_windows/18721/consoleFull,
```
01:22:55 launch_testing_examples\check_multiple_nodes_launch_test.py RR.          [ 22%]
```

Failure log in https://ci.ros2.org/job/ci_windows/18738/consoleFull.
```
23:58:21 launch_testing_examples\check_multiple_nodes_launch_test.py RRF          [ 22%]
```

We can find two `re-test` actions even in the successful log. (RR.)

