### PR TITLE
Fix errors under Windows

### DIFF
--- a/rclcpp/topics/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/topics/minimal_subscriber/CMakeLists.txt
@@ -36,7 +36,12 @@ ament_target_dependencies(subscriber_not_composable rclcpp std_msgs)
 add_executable(subscriber_content_filtering content_filtering.cpp)
 ament_target_dependencies(subscriber_content_filtering rclcpp std_msgs)
 
-add_library(wait_set_subscriber_library SHARED
+if(WIN32)
+    set(LIB_TYPE STATIC)
+else()
+    set(LIB_TYPE SHARED)
+endif()
+add_library(wait_set_subscriber_library ${LIB_TYPE}
     wait_set_subscriber.cpp
     static_wait_set_subscriber.cpp
     time_triggered_wait_set_subscriber.cpp)


### PR DESCRIPTION
Building under Windows can cause exceptions:
```
--- stderr: examples_rclcpp_minimal_subscriber
CMake Error at ament_cmake_symlink_install/ament_cmake_symlink_install.cmake:267 (message):
  ament_cmake_symlink_install_targets() can't find
  'xxxxx/build/examples_rclcpp_minimal_subscriber/Release/wait_set_subscriber_library.lib'
Call Stack (most recent call first):
  ament_cmake_symlink_install_targets_3_Release.cmake:1 (ament_cmake_symlink_install_targets)
  ament_cmake_symlink_install/ament_cmake_symlink_install.cmake:323 (include)
  cmake_install.cmake:36 (include)
```
refer to [CSDN](https://blog.csdn.net/tanmx219/article/details/126211384)