### PR TITLE
Split lambda and subscription definition in minimal subscriber example

### DIFF
--- a/rclcpp/topics/minimal_subscriber/lambda.cpp
+++ b/rclcpp/topics/minimal_subscriber/lambda.cpp
@@ -23,12 +23,12 @@ public:
   MinimalSubscriber()
   : Node("minimal_subscriber")
   {
-    subscription_ = this->create_subscription<std_msgs::msg::String>(
-      "topic",
-      10,
-      [this](std_msgs::msg::String::UniquePtr msg) {
+    auto topic_callback =
+      [this](std_msgs::msg::String::UniquePtr msg) -> void {
         RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
-      });
+      };
+    subscription_ =
+      this->create_subscription<std_msgs::msg::String>("topic", 10, topic_callback);
   }
 
 private:


### PR DESCRIPTION
The current example of minimal subscriber using a lambda function performs the definition of the subscription and the lambda function in the same line.

This PR splits the same operation in two steps, the definition of the lambda function and then the definition of the subscription. The goal is make it easier to explain what is happening in each step, as this example will be the default one in the ROS 2 documentation page (see https://github.com/ros2/ros2_documentation/issues/3618). Another benefit is that the minimal subscriber with lambdas would now follow the same structure of the minimal publisher with lambdas (i.e. declaration of the lambda and then declaration of the publisher/subscriber)

The name of the lambda function variable is `topic_callback` in order to match the same pattern from the minimal subscriber member function example