### PR TITLE
fix: Fixed compilation after API change of TimerBase::execute

### DIFF
--- a/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
+++ b/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
@@ -71,7 +71,9 @@ public:
         case rclcpp::WaitResultKind::Ready:
           {
             if (wait_result.get_wait_set().get_rcl_wait_set().timers[0U]) {
-              timer_->execute_callback();
+              if (auto data = timer_->call()) {
+                timer_->execute_callback(data);
+              }
             }
             break;
           }

--- a/rclcpp/wait_set/src/wait_set_topics_and_timer.cpp
+++ b/rclcpp/wait_set/src/wait_set_topics_and_timer.cpp
@@ -71,8 +71,10 @@ int32_t main(const int32_t argc, char ** const argv)
     const auto wait_result = wait_set.wait(2s);
     if (wait_result.kind() == rclcpp::WaitResultKind::Ready) {
       if (wait_result.get_wait_set().get_rcl_wait_set().timers[0U]) {
-        // The timer callback is executed manually here
-        one_off_timer->execute_callback();
+        if (auto data = one_off_timer->call()) {
+          // The timer callback is executed manually here
+          one_off_timer->execute_callback(data);
+        }
       } else {
         std_msgs::msg::String msg;
         rclcpp::MessageInfo msg_info;


### PR DESCRIPTION
This is a followup of https://github.com/ros2/rclcpp/pull/2343