### PR TITLE
Update the shutdown handling in all of the Python examples.

### DIFF
--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client.py
@@ -83,8 +83,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
 
 import rclpy
 from rclpy.action import ActionClient
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -70,11 +73,18 @@ class MinimalActionClient(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    action_client = MinimalActionClient()
+    try:
+        action_client = MinimalActionClient()
 
-    action_client.send_goal()
+        action_client.send_goal()
 
-    rclpy.spin(action_client)
+        rclpy.spin(action_client)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_cancel.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_cancel.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.action import Fibonacci
 
 import rclpy
 from rclpy.action import ActionClient
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -78,11 +81,18 @@ class MinimalActionClient(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    action_client = MinimalActionClient()
+    try:
+        action_client = MinimalActionClient()
 
-    action_client.send_goal()
+        action_client.send_goal()
 
-    rclpy.spin(action_client)
+        rclpy.spin(action_client)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_cancel.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_cancel.py
@@ -91,8 +91,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_not_composable.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_not_composable.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from action_msgs.msg import GoalStatus
 
 from example_interfaces.action import Fibonacci
 
 import rclpy
 from rclpy.action import ActionClient
+from rclpy.executors import ExternalShutdownException
 
 
 def feedback_cb(logger, feedback):
@@ -27,50 +30,53 @@ def feedback_cb(logger, feedback):
 def main(args=None):
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_action_client')
+    try:
+        node = rclpy.create_node('minimal_action_client')
 
-    action_client = ActionClient(node, Fibonacci, 'fibonacci')
+        action_client = ActionClient(node, Fibonacci, 'fibonacci')
 
-    node.get_logger().info('Waiting for action server...')
+        node.get_logger().info('Waiting for action server...')
 
-    action_client.wait_for_server()
+        action_client.wait_for_server()
 
-    goal_msg = Fibonacci.Goal()
-    goal_msg.order = 10
+        goal_msg = Fibonacci.Goal()
+        goal_msg.order = 10
 
-    node.get_logger().info('Sending goal request...')
+        node.get_logger().info('Sending goal request...')
 
-    send_goal_future = action_client.send_goal_async(
-        goal_msg, feedback_callback=lambda feedback: feedback_cb(node.get_logger(), feedback))
+        send_goal_future = action_client.send_goal_async(
+            goal_msg, feedback_callback=lambda feedback: feedback_cb(node.get_logger(), feedback))
 
-    rclpy.spin_until_future_complete(node, send_goal_future)
+        rclpy.spin_until_future_complete(node, send_goal_future)
 
-    goal_handle = send_goal_future.result()
+        goal_handle = send_goal_future.result()
 
-    if not goal_handle.accepted:
-        node.get_logger().info('Goal rejected :(')
-        action_client.destroy()
-        node.destroy_node()
-        rclpy.shutdown()
-        return
+        if not goal_handle.accepted:
+            node.get_logger().info('Goal rejected :(')
+            action_client.destroy()
+            node.destroy_node()
+            rclpy.shutdown()
+            return
 
-    node.get_logger().info('Goal accepted :)')
+        node.get_logger().info('Goal accepted :)')
 
-    get_result_future = goal_handle.get_result_async()
+        get_result_future = goal_handle.get_result_async()
 
-    rclpy.spin_until_future_complete(node, get_result_future)
+        rclpy.spin_until_future_complete(node, get_result_future)
 
-    result = get_result_future.result().result
-    status = get_result_future.result().status
-    if status == GoalStatus.STATUS_SUCCEEDED:
-        node.get_logger().info(
-           'Goal succeeded! Result: {0}'.format(result.sequence))
-    else:
-        node.get_logger().info('Goal failed with status code: {0}'.format(status))
-
-    action_client.destroy()
-    node.destroy_node()
-    rclpy.shutdown()
+        result = get_result_future.result().result
+        status = get_result_future.result().status
+        if status == GoalStatus.STATUS_SUCCEEDED:
+            node.get_logger().info(
+               'Goal succeeded! Result: {0}'.format(result.sequence))
+        else:
+            node.get_logger().info('Goal failed with status code: {0}'.format(status))
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_not_composable.py
+++ b/rclpy/actions/minimal_action_client/examples_rclpy_minimal_action_client/client_not_composable.py
@@ -75,8 +75,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 
 from example_interfaces.action import Fibonacci
@@ -19,6 +20,7 @@ from example_interfaces.action import Fibonacci
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -92,15 +94,19 @@ class MinimalActionServer(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_action_server = MinimalActionServer()
+    try:
+        minimal_action_server = MinimalActionServer()
 
-    # Use a MultiThreadedExecutor to enable processing goals concurrently
-    executor = MultiThreadedExecutor()
+        # Use a MultiThreadedExecutor to enable processing goals concurrently
+        executor = MultiThreadedExecutor()
 
-    rclpy.spin(minimal_action_server, executor=executor)
-
-    minimal_action_server.destroy()
-    rclpy.shutdown()
+        rclpy.spin(minimal_action_server, executor=executor)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server.py
@@ -105,8 +105,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_defer.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_defer.py
@@ -119,8 +119,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_defer.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_defer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 
 from example_interfaces.action import Fibonacci
@@ -19,6 +20,7 @@ from example_interfaces.action import Fibonacci
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -106,15 +108,19 @@ class MinimalActionServer(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_action_server = MinimalActionServer()
+    try:
+        minimal_action_server = MinimalActionServer()
 
-    # Use a MultiThreadedExecutor to enable processing goals concurrently
-    executor = MultiThreadedExecutor()
+        # Use a MultiThreadedExecutor to enable processing goals concurrently
+        executor = MultiThreadedExecutor()
 
-    rclpy.spin(minimal_action_server, executor=executor)
-
-    minimal_action_server.destroy()
-    rclpy.shutdown()
+        rclpy.spin(minimal_action_server, executor=executor)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_not_composable.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_not_composable.py
@@ -97,8 +97,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_not_composable.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_not_composable.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 
 from example_interfaces.action import Fibonacci
@@ -19,6 +20,7 @@ from example_interfaces.action import Fibonacci
 import rclpy
 from rclpy.action import ActionServer, CancelResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 
 
@@ -71,28 +73,32 @@ def main(args=None):
     global logger
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_action_server')
-    logger = node.get_logger()
+    try:
+        node = rclpy.create_node('minimal_action_server')
+        logger = node.get_logger()
 
-    # Use a ReentrantCallbackGroup to enable processing multiple goals concurrently
-    # Default goal callback accepts all goals
-    # Default cancel callback rejects cancel requests
-    action_server = ActionServer(
-        node,
-        Fibonacci,
-        'fibonacci',
-        execute_callback=execute_callback,
-        cancel_callback=cancel_callback,
-        callback_group=ReentrantCallbackGroup())
+        # Use a ReentrantCallbackGroup to enable processing multiple goals concurrently
+        # Default goal callback accepts all goals
+        # Default cancel callback rejects cancel requests
+        action_server = ActionServer(
+            node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=execute_callback,
+            cancel_callback=cancel_callback,
+            callback_group=ReentrantCallbackGroup())
+        action_server  # Quiet flake8 warnings about unused variable
 
-    # Use a MultiThreadedExecutor to enable processing goals concurrently
-    executor = MultiThreadedExecutor()
+        # Use a MultiThreadedExecutor to enable processing goals concurrently
+        executor = MultiThreadedExecutor()
 
-    rclpy.spin(node, executor=executor)
-
-    action_server.destroy()
-    node.destroy_node()
-    rclpy.shutdown()
+        rclpy.spin(node, executor=executor)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_queue_goals.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_queue_goals.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import sys
 import threading
 import time
 
@@ -21,6 +22,7 @@ from example_interfaces.action import Fibonacci
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -123,14 +125,18 @@ class MinimalActionServer(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_action_server = MinimalActionServer()
+    try:
+        minimal_action_server = MinimalActionServer()
 
-    executor = MultiThreadedExecutor()
+        executor = MultiThreadedExecutor()
 
-    rclpy.spin(minimal_action_server, executor=executor)
-
-    minimal_action_server.destroy()
-    rclpy.shutdown()
+        rclpy.spin(minimal_action_server, executor=executor)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_queue_goals.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_queue_goals.py
@@ -135,8 +135,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_single_goal.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_single_goal.py
@@ -124,8 +124,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_single_goal.py
+++ b/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server_single_goal.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import threading
 import time
 
@@ -20,6 +21,7 @@ from example_interfaces.action import Fibonacci
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -112,14 +114,18 @@ class MinimalActionServer(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    action_server = MinimalActionServer()
+    try:
+        action_server = MinimalActionServer()
 
-    # We use a MultiThreadedExecutor to handle incoming goal requests concurrently
-    executor = MultiThreadedExecutor()
-    rclpy.spin(action_server, executor=executor)
-
-    action_server.destroy()
-    rclpy.shutdown()
+        # We use a MultiThreadedExecutor to handle incoming goal requests concurrently
+        executor = MultiThreadedExecutor()
+        rclpy.spin(action_server, executor=executor)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/callback_group.py
@@ -66,8 +66,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/callback_group.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from examples_rclpy_executors.listener import Listener
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from std_msgs.msg import String
@@ -58,14 +61,13 @@ def main(args=None):
         executor.add_node(talker)
         executor.add_node(listener)
 
-        try:
-            executor.spin()
-        finally:
-            executor.shutdown()
-            listener.destroy_node()
-            talker.destroy_node()
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
     finally:
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/composed.py
+++ b/rclpy/executors/examples_rclpy_executors/composed.py
@@ -33,13 +33,8 @@ def main(args=None):
         executor.add_node(talker)
         executor.add_node(listener)
 
-        try:
-            # Execute callbacks for both nodes as they become ready
-            executor.spin()
-        finally:
-            executor.shutdown()
-            listener.destroy_node()
-            talker.destroy_node()
+        # Execute callbacks for both nodes as they become ready
+        executor.spin()
     except KeyboardInterrupt:
         pass
     except ExternalShutdownException:

--- a/rclpy/executors/examples_rclpy_executors/composed.py
+++ b/rclpy/executors/examples_rclpy_executors/composed.py
@@ -39,8 +39,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/custom_callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_callback_group.py
@@ -109,7 +109,6 @@ def main(args=None):
         sys.exit(1)
     finally:
         rclpy.try_shutdown()
-        talker.destroy_node()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/custom_callback_group.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_callback_group.py
@@ -107,8 +107,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/custom_executor.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_executor.py
@@ -95,8 +95,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/custom_executor.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_executor.py
@@ -14,11 +14,13 @@
 
 from concurrent.futures import ThreadPoolExecutor
 import os
+import sys
 
 from examples_rclpy_executors.listener import Listener
 from examples_rclpy_executors.talker import Talker
 import rclpy
 from rclpy.executors import Executor
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_msgs.msg import String
 
@@ -88,15 +90,13 @@ def main(args=None):
         executor.add_high_priority_node(estopper)
         executor.add_node(listener)
         executor.add_node(talker)
-        try:
-            executor.spin()
-        finally:
-            executor.shutdown()
-            estopper.destroy_node()
-            talker.destroy_node()
-            listener.destroy_node()
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
     finally:
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/listener.py
+++ b/rclpy/executors/examples_rclpy_executors/listener.py
@@ -58,7 +58,6 @@ def main(args=None):
         sys.exit(1)
     finally:
         rclpy.try_shutdown()
-        listener.destroy_node()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/listener.py
+++ b/rclpy/executors/examples_rclpy_executors/listener.py
@@ -56,8 +56,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/talker.py
+++ b/rclpy/executors/examples_rclpy_executors/talker.py
@@ -66,8 +66,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/executors/examples_rclpy_executors/talker.py
+++ b/rclpy/executors/examples_rclpy_executors/talker.py
@@ -68,7 +68,6 @@ def main(args=None):
         sys.exit(1)
     finally:
         rclpy.try_shutdown()
-        talker.destroy_node()
 
 
 if __name__ == '__main__':

--- a/rclpy/guard_conditions/examples_rclpy_guard_conditions/trigger_guard_condition.py
+++ b/rclpy/guard_conditions/examples_rclpy_guard_conditions/trigger_guard_condition.py
@@ -49,8 +49,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/guard_conditions/examples_rclpy_guard_conditions/trigger_guard_condition.py
+++ b/rclpy/guard_conditions/examples_rclpy_guard_conditions/trigger_guard_condition.py
@@ -12,36 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 
 def main(args=None):
-
     rclpy.init(args=args)
-    node = rclpy.create_node('demo_guard_condition')
-    executor = rclpy.executors.SingleThreadedExecutor()
-    executor.add_node(node)
+    try:
+        node = rclpy.create_node('demo_guard_condition')
+        executor = rclpy.executors.SingleThreadedExecutor()
+        executor.add_node(node)
 
-    def guard_condition_callback():
-        rclpy.shutdown()
-        node.get_logger().info('guard callback called shutdown')
+        def guard_condition_callback():
+            rclpy.shutdown()
+            node.get_logger().info('guard callback called shutdown')
 
-    def timer_callback():
-        guard_condition.trigger()
-        node.get_logger().info('timer callback triggered guard condition')
+        def timer_callback():
+            guard_condition.trigger()
+            node.get_logger().info('timer callback triggered guard condition')
 
-    node.create_timer(timer_period_sec=2, callback=timer_callback)
-    guard_condition = node.create_guard_condition(guard_condition_callback)
+        node.create_timer(timer_period_sec=2, callback=timer_callback)
+        guard_condition = node.create_guard_condition(guard_condition_callback)
 
-    while rclpy.ok():
-        # First loop: `spin_once` waits for timer to be ready, then calls
-        #   the timer's callback, which triggers the guard condition.
-        # Second loop: The guard condition is ready so it's callback is
-        #   called. The callback calls shutdown, so the loop doesn't run
-        #   again and the program exits.
-        node.get_logger().info("waiting for 'spin_once' to finish...")
-        executor.spin_once()
-        node.get_logger().info("...'spin_once' finished!\n")
+        while rclpy.ok():
+            # First loop: `spin_once` waits for timer to be ready, then calls
+            #   the timer's callback, which triggers the guard condition.
+            # Second loop: The guard condition is ready so it's callback is
+            #   called. The callback calls shutdown, so the loop doesn't run
+            #   again and the program exits.
+            node.get_logger().info("waiting for 'spin_once' to finish...")
+            executor.spin_once()
+            node.get_logger().info("...'spin_once' finished!\n")
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py
@@ -12,32 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 
 def main(args=None):
     rclpy.init(args=args)
-    node = rclpy.create_node('minimal_client')
-    cli = node.create_client(AddTwoInts, 'add_two_ints')
 
-    req = AddTwoInts.Request()
-    req.a = 41
-    req.b = 1
-    while not cli.wait_for_service(timeout_sec=1.0):
-        node.get_logger().info('service not available, waiting again...')
+    try:
+        node = rclpy.create_node('minimal_client')
+        cli = node.create_client(AddTwoInts, 'add_two_ints')
 
-    future = cli.call_async(req)
-    rclpy.spin_until_future_complete(node, future)
+        req = AddTwoInts.Request()
+        req.a = 41
+        req.b = 1
+        while not cli.wait_for_service(timeout_sec=1.0):
+            node.get_logger().info('service not available, waiting again...')
 
-    result = future.result()
-    node.get_logger().info(
-        'Result of add_two_ints: for %d + %d = %d' %
-        (req.a, req.b, result.sum))
+        future = cli.call_async(req)
+        rclpy.spin_until_future_complete(node, future)
 
-    node.destroy_node()
-    rclpy.shutdown()
+        result = future.result()
+        node.get_logger().info(
+            'Result of add_two_ints: for %d + %d = %d' %
+            (req.a, req.b, result.sum))
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py
@@ -44,8 +44,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async.py
@@ -47,8 +47,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async.py
@@ -12,36 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 
 def main(args=None):
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_client_async')
+    try:
+        node = rclpy.create_node('minimal_client_async')
 
-    cli = node.create_client(AddTwoInts, 'add_two_ints')
+        cli = node.create_client(AddTwoInts, 'add_two_ints')
 
-    req = AddTwoInts.Request()
-    req.a = 41
-    req.b = 1
-    while not cli.wait_for_service(timeout_sec=1.0):
-        node.get_logger().info('service not available, waiting again...')
+        req = AddTwoInts.Request()
+        req.a = 41
+        req.b = 1
+        while not cli.wait_for_service(timeout_sec=1.0):
+            node.get_logger().info('service not available, waiting again...')
 
-    future = cli.call_async(req)
-    while rclpy.ok():
-        rclpy.spin_once(node)
-        if future.done():
-            result = future.result()
-            node.get_logger().info(
-                'Result of add_two_ints: for %d + %d = %d' %
-                (req.a, req.b, result.sum))
-            break
-
-    node.destroy_node()
-    rclpy.shutdown()
+        future = cli.call_async(req)
+        while rclpy.ok():
+            rclpy.spin_once(node)
+            if future.done():
+                result = future.result()
+                node.get_logger().info(
+                    'Result of add_two_ints: for %d + %d = %d' %
+                    (req.a, req.b, result.sum))
+                break
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py
@@ -12,55 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException
 
 
 def main(args=None):
     rclpy.init(args=args)
-    node = rclpy.create_node('minimal_client')
-    # Node's default callback group is mutually exclusive. This would prevent the client response
-    # from being processed until the timer callback finished, but the timer callback in this
-    # example is waiting for the client response
-    cb_group = ReentrantCallbackGroup()
-    cli = node.create_client(AddTwoInts, 'add_two_ints', callback_group=cb_group)
-    did_run = False
-    did_get_result = False
 
-    async def call_service():
-        nonlocal cli, node, did_run, did_get_result
-        did_run = True
-        try:
-            req = AddTwoInts.Request()
-            req.a = 41
-            req.b = 1
-            future = cli.call_async(req)
-            result = await future
-            node.get_logger().info(
-                'Result of add_two_ints: for %d + %d = %d' %
-                (req.a, req.b, result.sum))
-        finally:
-            did_get_result = True
+    try:
+        node = rclpy.create_node('minimal_client')
+        # Node's default callback group is mutually exclusive. This would prevent the client
+        # response from being processed until the timer callback finished, but the timer callback
+        # int this example is waiting for the client response
+        cb_group = ReentrantCallbackGroup()
+        cli = node.create_client(AddTwoInts, 'add_two_ints', callback_group=cb_group)
+        did_run = False
+        did_get_result = False
 
-    while not cli.wait_for_service(timeout_sec=1.0):
-        node.get_logger().info('service not available, waiting again...')
+        async def call_service():
+            nonlocal cli, node, did_run, did_get_result
+            did_run = True
+            try:
+                req = AddTwoInts.Request()
+                req.a = 41
+                req.b = 1
+                future = cli.call_async(req)
+                result = await future
+                node.get_logger().info(
+                    'Result of add_two_ints: for %d + %d = %d' %
+                    (req.a, req.b, result.sum))
+            finally:
+                did_get_result = True
 
-    timer = node.create_timer(0.5, call_service, callback_group=cb_group)
+        while not cli.wait_for_service(timeout_sec=1.0):
+            node.get_logger().info('service not available, waiting again...')
 
-    while rclpy.ok() and not did_run:
-        rclpy.spin_once(node)
+        timer = node.create_timer(0.5, call_service, callback_group=cb_group)
 
-    if did_run:
-        # call timer callback only once
-        timer.cancel()
+        while rclpy.ok() and not did_run:
+            rclpy.spin_once(node)
 
-    while rclpy.ok() and not did_get_result:
-        rclpy.spin_once(node)
+        if did_run:
+            # call timer callback only once
+            timer.cancel()
 
-    node.destroy_node()
-    rclpy.shutdown()
+        while rclpy.ok() and not did_get_result:
+            rclpy.spin_once(node)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py
@@ -67,8 +67,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_member_function.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_member_function.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -36,20 +39,24 @@ class MinimalClientAsync(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_client = MinimalClientAsync()
-    minimal_client.send_request()
+    try:
+        minimal_client = MinimalClientAsync()
+        minimal_client.send_request()
 
-    while rclpy.ok():
-        rclpy.spin_once(minimal_client)
-        if minimal_client.future.done():
-            response = minimal_client.future.result()
-            minimal_client.get_logger().info(
-                'Result of add_two_ints: for %d + %d = %d' %
-                (minimal_client.req.a, minimal_client.req.b, response.sum))
-            break
-
-    minimal_client.destroy_node()
-    rclpy.shutdown()
+        while rclpy.ok():
+            rclpy.spin_once(minimal_client)
+            if minimal_client.future.done():
+                response = minimal_client.future.result()
+                minimal_client.get_logger().info(
+                    'Result of add_two_ints: for %d + %d = %d' %
+                    (minimal_client.req.a, minimal_client.req.b, response.sum))
+                break
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_member_function.py
+++ b/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_member_function.py
@@ -55,8 +55,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_service/examples_rclpy_minimal_service/service.py
+++ b/rclpy/services/minimal_service/examples_rclpy_minimal_service/service.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 g_node = None
 
@@ -32,17 +35,20 @@ def main(args=None):
     global g_node
     rclpy.init(args=args)
 
-    g_node = rclpy.create_node('minimal_service')
+    try:
+        g_node = rclpy.create_node('minimal_service')
 
-    srv = g_node.create_service(AddTwoInts, 'add_two_ints', add_two_ints_callback)
-    while rclpy.ok():
-        rclpy.spin_once(g_node)
+        srv = g_node.create_service(AddTwoInts, 'add_two_ints', add_two_ints_callback)
+        srv  # Quiet flake8 warnings about unused variable
+        while rclpy.ok():
+            rclpy.spin_once(g_node)
 
-    # Destroy the service attached to the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    g_node.destroy_service(srv)
-    rclpy.shutdown()
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_service/examples_rclpy_minimal_service/service.py
+++ b/rclpy/services/minimal_service/examples_rclpy_minimal_service/service.py
@@ -47,8 +47,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_service/examples_rclpy_minimal_service/service_member_function.py
+++ b/rclpy/services/minimal_service/examples_rclpy_minimal_service/service_member_function.py
@@ -45,8 +45,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/services/minimal_service/examples_rclpy_minimal_service/service_member_function.py
+++ b/rclpy/services/minimal_service/examples_rclpy_minimal_service/service_member_function.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -34,11 +37,16 @@ class MinimalService(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_service = MinimalService()
+    try:
+        minimal_service = MinimalService()
 
-    rclpy.spin(minimal_service)
-
-    rclpy.shutdown()
+        rclpy.spin(minimal_service)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_local_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_local_function.py
@@ -46,8 +46,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_local_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_local_function.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 from std_msgs.msg import String
 
@@ -20,30 +23,31 @@ from std_msgs.msg import String
 def main(args=None):
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_publisher')
-    publisher = node.create_publisher(String, 'topic', 10)
+    try:
+        node = rclpy.create_node('minimal_publisher')
+        publisher = node.create_publisher(String, 'topic', 10)
 
-    msg = String()
-    i = 0
+        msg = String()
+        i = 0
 
-    def timer_callback():
-        nonlocal i
-        msg.data = 'Hello World: %d' % i
-        i += 1
-        node.get_logger().info('Publishing: "%s"' % msg.data)
-        publisher.publish(msg)
+        def timer_callback():
+            nonlocal i
+            msg.data = 'Hello World: %d' % i
+            i += 1
+            node.get_logger().info('Publishing: "%s"' % msg.data)
+            publisher.publish(msg)
 
-    timer_period = 0.5  # seconds
-    timer = node.create_timer(timer_period, timer_callback)
+        timer_period = 0.5  # seconds
+        timer = node.create_timer(timer_period, timer_callback)
+        timer  # Quiet flake8 warnings about unused variable
 
-    rclpy.spin(node)
-
-    # Destroy the timer attached to the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    node.destroy_timer(timer)
-    node.destroy_node()
-    rclpy.shutdown()
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from std_msgs.msg import String
@@ -38,15 +41,16 @@ class MinimalPublisher(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_publisher = MinimalPublisher()
+    try:
+        minimal_publisher = MinimalPublisher()
 
-    rclpy.spin(minimal_publisher)
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    minimal_publisher.destroy_node()
-    rclpy.shutdown()
+        rclpy.spin(minimal_publisher)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
@@ -49,8 +49,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_old_school.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_old_school.py
@@ -47,8 +47,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_old_school.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_old_school.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from time import sleep
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 from std_msgs.msg import String
 
@@ -27,25 +29,26 @@ from std_msgs.msg import String
 def main(args=None):
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_publisher')
+    try:
+        node = rclpy.create_node('minimal_publisher')
 
-    publisher = node.create_publisher(String, 'topic', 10)
+        publisher = node.create_publisher(String, 'topic', 10)
 
-    msg = String()
+        msg = String()
 
-    i = 0
-    while rclpy.ok():
-        msg.data = 'Hello World: %d' % i
-        i += 1
-        node.get_logger().info('Publishing: "%s"' % msg.data)
-        publisher.publish(msg)
-        sleep(0.5)  # seconds
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    node.destroy_node()
-    rclpy.shutdown()
+        i = 0
+        while rclpy.ok():
+            msg.data = 'Hello World: %d' % i
+            i += 1
+            node.get_logger().info('Publishing: "%s"' % msg.data)
+            publisher.publish(msg)
+            sleep(0.5)  # seconds
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_lambda.py
+++ b/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_lambda.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 from std_msgs.msg import String
 
@@ -20,19 +23,20 @@ from std_msgs.msg import String
 def main(args=None):
     rclpy.init(args=args)
 
-    node = rclpy.create_node('minimal_subscriber')
+    try:
+        node = rclpy.create_node('minimal_subscriber')
 
-    subscription = node.create_subscription(
-        String, 'topic', lambda msg: node.get_logger().info('I heard: "%s"' % msg.data), 10)
-    subscription  # prevent unused variable warning
+        subscription = node.create_subscription(
+            String, 'topic', lambda msg: node.get_logger().info('I heard: "%s"' % msg.data), 10)
+        subscription  # prevent unused variable warning
 
-    rclpy.spin(node)
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    node.destroy_node()
-    rclpy.shutdown()
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_lambda.py
+++ b/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_lambda.py
@@ -35,8 +35,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+++ b/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
@@ -47,8 +47,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+++ b/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from std_msgs.msg import String
@@ -36,15 +39,16 @@ class MinimalSubscriber(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_subscriber = MinimalSubscriber()
+    try:
+        minimal_subscriber = MinimalSubscriber()
 
-    rclpy.spin(minimal_subscriber)
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    minimal_subscriber.destroy_node()
-    rclpy.shutdown()
+        rclpy.spin(minimal_subscriber)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_old_school.py
+++ b/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_old_school.py
@@ -44,8 +44,6 @@ def main(args=None):
         pass
     except ExternalShutdownException:
         sys.exit(1)
-    finally:
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_old_school.py
+++ b/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_old_school.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 from std_msgs.msg import String
 
@@ -29,19 +32,20 @@ def main(args=None):
     global g_node
     rclpy.init(args=args)
 
-    g_node = rclpy.create_node('minimal_subscriber')
+    try:
+        g_node = rclpy.create_node('minimal_subscriber')
 
-    subscription = g_node.create_subscription(String, 'topic', chatter_callback, 10)
-    subscription  # prevent unused variable warning
+        subscription = g_node.create_subscription(String, 'topic', chatter_callback, 10)
+        subscription  # prevent unused variable warning
 
-    while rclpy.ok():
-        rclpy.spin_once(g_node)
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    g_node.destroy_node()
-    rclpy.shutdown()
+        while rclpy.ok():
+            rclpy.spin_once(g_node)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/topics/pointcloud_publisher/examples_rclpy_pointcloud_publisher/pointcloud_publisher.py
+++ b/rclpy/topics/pointcloud_publisher/examples_rclpy_pointcloud_publisher/pointcloud_publisher.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import numpy as np
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from sensor_msgs.msg import PointCloud2
 from sensor_msgs.msg import PointField
@@ -60,10 +63,13 @@ class PointCloudPublisher(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    pc_publisher = PointCloudPublisher()
-    rclpy.spin(pc_publisher)
-    pc_publisher.destroy_node()
-    rclpy.shutdown()
+    try:
+        pc_publisher = PointCloudPublisher()
+        rclpy.spin(pc_publisher)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In particular, we should deal with KeyboardInterrupt (by just doing 'pass'), as well as ExternalShutdownException (which can come from the executor).  In all cases, we should call 'rclpy.try_shutdown()' to cleanup at the end.

Note well that I removed some of the *destroy() calls in the cleanup.  That's because they weren't correct in all cases, and to fix them up properly would really require us to have a nested set of try..except statements.  Given that these are examples, having that complex set of exception handling didn't seem like the correct way to go here.

This should fix #372 .  @fujitatomoya FYI