### PR TITLE
Use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/rclcpp/actions/minimal_action_client/CMakeLists.txt
+++ b/rclcpp/actions/minimal_action_client/CMakeLists.txt
@@ -17,28 +17,28 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 
 add_executable(action_client_member_functions member_functions.cpp)
-ament_target_dependencies(action_client_member_functions
-  "rclcpp"
-  "rclcpp_action"
-  "example_interfaces")
+target_link_libraries(action_client_member_functions PRIVATE
+  ${example_interfaces_TARGETS}
+  rclcpp::rclcpp 
+  rclcpp_action::rclcpp_action)
 
 add_executable(action_client_not_composable not_composable.cpp)
-ament_target_dependencies(action_client_not_composable
-  "rclcpp"
-  "rclcpp_action"
-  "example_interfaces")
+target_link_libraries(action_client_not_composable PRIVATE
+  ${example_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action)
 
 add_executable(action_client_not_composable_with_cancel not_composable_with_cancel.cpp)
-ament_target_dependencies(action_client_not_composable_with_cancel
-  "rclcpp"
-  "rclcpp_action"
-  "example_interfaces")
+target_link_libraries(action_client_not_composable_with_cancel PRIVATE
+  ${example_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action)
 
 add_executable(action_client_not_composable_with_feedback not_composable_with_feedback.cpp)
-ament_target_dependencies(action_client_not_composable_with_feedback
-  "rclcpp"
-  "rclcpp_action"
-  "example_interfaces")
+target_link_libraries(action_client_not_composable_with_feedback PRIVATE
+  ${example_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rclcpp/actions/minimal_action_client/CMakeLists.txt
+++ b/rclcpp/actions/minimal_action_client/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(rclcpp_action REQUIRED)
 add_executable(action_client_member_functions member_functions.cpp)
 target_link_libraries(action_client_member_functions PRIVATE
   ${example_interfaces_TARGETS}
-  rclcpp::rclcpp 
+  rclcpp::rclcpp
   rclcpp_action::rclcpp_action)
 
 add_executable(action_client_not_composable not_composable.cpp)

--- a/rclcpp/actions/minimal_action_server/CMakeLists.txt
+++ b/rclcpp/actions/minimal_action_server/CMakeLists.txt
@@ -17,16 +17,16 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 
 add_executable(action_server_member_functions member_functions.cpp)
-ament_target_dependencies(action_server_member_functions
-  "rclcpp"
-  "rclcpp_action"
-  "example_interfaces")
+target_link_libraries(action_server_member_functions PRIVATE
+  ${example_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action)
 
 add_executable(action_server_not_composable not_composable.cpp)
-ament_target_dependencies(action_server_not_composable
-  "rclcpp"
-  "rclcpp_action"
-  "example_interfaces")
+target_link_libraries(action_server_not_composable PRIVATE
+  ${example_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rclcpp/composition/minimal_composition/CMakeLists.txt
+++ b/rclcpp/composition/minimal_composition/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(composition_nodes SHARED
             src/subscriber_node.cpp)
 target_compile_definitions(composition_nodes
   PRIVATE "MINIMAL_COMPOSITION_DLL")
-ament_target_dependencies(composition_nodes rclcpp rclcpp_components std_msgs)
+target_link_libraries(composition_nodes PUBLIC rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 
 # This package installs libraries without exporting them.
 # Export the library path to ensure that the installed libraries are available.
@@ -33,18 +33,13 @@ if(NOT WIN32)
 endif()
 
 add_executable(composition_publisher src/standalone_publisher.cpp)
-target_link_libraries(composition_publisher composition_nodes)
-ament_target_dependencies(composition_publisher
-  rclcpp)
+target_link_libraries(composition_publisher PRIVATE composition_nodes rclcpp::rclcpp)
 
 add_executable(composition_subscriber src/standalone_subscriber.cpp)
-target_link_libraries(composition_subscriber composition_nodes)
-ament_target_dependencies(composition_subscriber
-  rclcpp)
+target_link_libraries(composition_subscriber PRIVATE composition_nodes rclcpp::rclcpp)
 
 add_executable(composition_composed src/composed.cpp)
-target_link_libraries(composition_composed composition_nodes)
-ament_target_dependencies(composition_composed rclcpp class_loader)
+target_link_libraries(composition_composed PRIVATE composition_nodes rclcpp::rclcpp class_loader::class_loader)
 
 install(TARGETS
   composition_nodes

--- a/rclcpp/composition/minimal_composition/CMakeLists.txt
+++ b/rclcpp/composition/minimal_composition/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(composition_nodes SHARED
             src/publisher_node.cpp
             src/subscriber_node.cpp)
 target_compile_definitions(composition_nodes
-  PRIVATE "MINIMAL_COMPOSITION_DLL")
+ PRIVATE "MINIMAL_COMPOSITION_DLL")
 target_link_libraries(composition_nodes PUBLIC rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 
 # This package installs libraries without exporting them.

--- a/rclcpp/composition/minimal_composition/CMakeLists.txt
+++ b/rclcpp/composition/minimal_composition/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(composition_nodes SHARED
             src/publisher_node.cpp
             src/subscriber_node.cpp)
 target_compile_definitions(composition_nodes
- PRIVATE "MINIMAL_COMPOSITION_DLL")
+  PRIVATE "MINIMAL_COMPOSITION_DLL")
 target_link_libraries(composition_nodes PUBLIC rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 
 # This package installs libraries without exporting them.

--- a/rclcpp/executors/cbg_executor/CMakeLists.txt
+++ b/rclcpp/executors/cbg_executor/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(
   src/examples_rclcpp_cbg_executor/ping_node.cpp
 )
 target_include_directories(ping PUBLIC include)
-ament_target_dependencies(ping rclcpp std_msgs)
+target_link_libraries(ping PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(
   pong
@@ -29,7 +29,7 @@ add_executable(
   src/examples_rclcpp_cbg_executor/pong_node.cpp
 )
 target_include_directories(pong PUBLIC include)
-ament_target_dependencies(pong rclcpp std_msgs)
+target_link_libraries(pong PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(
   ping_pong
@@ -38,7 +38,7 @@ add_executable(
   src/examples_rclcpp_cbg_executor/pong_node.cpp
 )
 target_include_directories(ping_pong PUBLIC include)
-ament_target_dependencies(ping_pong rclcpp std_msgs)
+target_link_libraries(ping_pong PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 install(TARGETS ping pong ping_pong
   DESTINATION lib/${PROJECT_NAME}

--- a/rclcpp/executors/multithreaded_executor/CMakeLists.txt
+++ b/rclcpp/executors/multithreaded_executor/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_executable(multithreaded_executor multithreaded_executor.cpp)
-ament_target_dependencies(multithreaded_executor rclcpp std_msgs)
+target_link_libraries(multithreaded_executor PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 install(TARGETS
   multithreaded_executor

--- a/rclcpp/services/async_client/CMakeLists.txt
+++ b/rclcpp/services/async_client/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(client_main main.cpp)
-ament_target_dependencies(client_main rclcpp example_interfaces)
+target_link_libraries(client_main PRIVATE rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 install(TARGETS client_main
   DESTINATION lib/${PROJECT_NAME})

--- a/rclcpp/services/minimal_client/CMakeLists.txt
+++ b/rclcpp/services/minimal_client/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(client_main main.cpp)
-ament_target_dependencies(client_main rclcpp example_interfaces)
+target_link_libraries(client_main PRIVATE rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 install(TARGETS client_main
   DESTINATION lib/${PROJECT_NAME})

--- a/rclcpp/services/minimal_service/CMakeLists.txt
+++ b/rclcpp/services/minimal_service/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(service_main main.cpp)
-ament_target_dependencies(service_main rclcpp example_interfaces)
+target_link_libraries(service_main PRIVATE rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 install(TARGETS service_main
   DESTINATION lib/${PROJECT_NAME})

--- a/rclcpp/timers/minimal_timer/CMakeLists.txt
+++ b/rclcpp/timers/minimal_timer/CMakeLists.txt
@@ -15,10 +15,10 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(timer_lambda lambda.cpp)
-ament_target_dependencies(timer_lambda rclcpp)
+target_link_libraries(timer_lambda PRIVATE rclcpp::rclcpp)
 
 add_executable(timer_member_function member_function.cpp)
-ament_target_dependencies(timer_member_function rclcpp)
+target_link_libraries(timer_member_function PRIVATE rclcpp::rclcpp)
 
 install(TARGETS
   timer_lambda

--- a/rclcpp/topics/minimal_publisher/CMakeLists.txt
+++ b/rclcpp/topics/minimal_publisher/CMakeLists.txt
@@ -16,22 +16,22 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_executable(publisher_lambda lambda.cpp)
-target_link_libraries(publisher_lambda  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(publisher_lambda PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_member_function member_function.cpp)
-target_link_libraries(publisher_member_function  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(publisher_member_function PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_member_function_with_type_adapter member_function_with_type_adapter.cpp)
-target_link_libraries(publisher_member_function_with_type_adapter  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(publisher_member_function_with_type_adapter PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_member_function_with_unique_network_flow_endpoints member_function_with_unique_network_flow_endpoints.cpp)
-target_link_libraries(publisher_member_function_with_unique_network_flow_endpoints  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(publisher_member_function_with_unique_network_flow_endpoints PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_wait_for_all_acked member_function_with_wait_for_all_acked.cpp)
-target_link_libraries(publisher_wait_for_all_acked  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(publisher_wait_for_all_acked PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_not_composable not_composable.cpp)
-target_link_libraries(publisher_not_composable  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(publisher_not_composable PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 install(TARGETS
   publisher_lambda

--- a/rclcpp/topics/minimal_publisher/CMakeLists.txt
+++ b/rclcpp/topics/minimal_publisher/CMakeLists.txt
@@ -16,22 +16,22 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_executable(publisher_lambda lambda.cpp)
-ament_target_dependencies(publisher_lambda rclcpp std_msgs)
+target_link_libraries(publisher_lambda  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_member_function member_function.cpp)
-ament_target_dependencies(publisher_member_function rclcpp std_msgs)
+target_link_libraries(publisher_member_function  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_member_function_with_type_adapter member_function_with_type_adapter.cpp)
-ament_target_dependencies(publisher_member_function_with_type_adapter rclcpp std_msgs)
+target_link_libraries(publisher_member_function_with_type_adapter  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_member_function_with_unique_network_flow_endpoints member_function_with_unique_network_flow_endpoints.cpp)
-ament_target_dependencies(publisher_member_function_with_unique_network_flow_endpoints rclcpp std_msgs)
+target_link_libraries(publisher_member_function_with_unique_network_flow_endpoints  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_wait_for_all_acked member_function_with_wait_for_all_acked.cpp)
-ament_target_dependencies(publisher_wait_for_all_acked rclcpp std_msgs)
+target_link_libraries(publisher_wait_for_all_acked  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(publisher_not_composable not_composable.cpp)
-ament_target_dependencies(publisher_not_composable rclcpp std_msgs)
+target_link_libraries(publisher_not_composable  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 install(TARGETS
   publisher_lambda

--- a/rclcpp/topics/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/topics/minimal_subscriber/CMakeLists.txt
@@ -17,31 +17,31 @@ find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_executable(subscriber_lambda lambda.cpp)
-ament_target_dependencies(subscriber_lambda rclcpp std_msgs)
+target_link_libraries(subscriber_lambda PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function member_function.cpp)
-ament_target_dependencies(subscriber_member_function rclcpp std_msgs)
+target_link_libraries(subscriber_member_function  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function_with_topic_statistics member_function_with_topic_statistics.cpp)
-ament_target_dependencies(subscriber_member_function_with_topic_statistics rclcpp std_msgs)
+target_link_libraries(subscriber_member_function_with_topic_statistics  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function_with_type_adapter member_function_with_type_adapter.cpp)
-ament_target_dependencies(subscriber_member_function_with_type_adapter rclcpp std_msgs)
+target_link_libraries(subscriber_member_function_with_type_adapter  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function_with_unique_network_flow_endpoints member_function_with_unique_network_flow_endpoints.cpp)
-ament_target_dependencies(subscriber_member_function_with_unique_network_flow_endpoints rclcpp std_msgs)
+target_link_libraries(subscriber_member_function_with_unique_network_flow_endpoints  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_not_composable not_composable.cpp)
-ament_target_dependencies(subscriber_not_composable rclcpp std_msgs)
+target_link_libraries(subscriber_not_composable  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_content_filtering content_filtering.cpp)
-ament_target_dependencies(subscriber_content_filtering rclcpp std_msgs)
+target_link_libraries(subscriber_content_filtering  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_library(wait_set_subscriber_library SHARED
     wait_set_subscriber.cpp
     static_wait_set_subscriber.cpp
     time_triggered_wait_set_subscriber.cpp)
-ament_target_dependencies(wait_set_subscriber_library rclcpp rclcpp_components std_msgs)
+target_link_libraries(wait_set_subscriber_library  PRIVATE rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 
 rclcpp_components_register_node(wait_set_subscriber_library
     PLUGIN "WaitSetSubscriber"

--- a/rclcpp/topics/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/topics/minimal_subscriber/CMakeLists.txt
@@ -20,28 +20,28 @@ add_executable(subscriber_lambda lambda.cpp)
 target_link_libraries(subscriber_lambda PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function member_function.cpp)
-target_link_libraries(subscriber_member_function  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(subscriber_member_function PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function_with_topic_statistics member_function_with_topic_statistics.cpp)
-target_link_libraries(subscriber_member_function_with_topic_statistics  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(subscriber_member_function_with_topic_statistics PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function_with_type_adapter member_function_with_type_adapter.cpp)
-target_link_libraries(subscriber_member_function_with_type_adapter  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(subscriber_member_function_with_type_adapter PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_member_function_with_unique_network_flow_endpoints member_function_with_unique_network_flow_endpoints.cpp)
-target_link_libraries(subscriber_member_function_with_unique_network_flow_endpoints  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(subscriber_member_function_with_unique_network_flow_endpoints PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_not_composable not_composable.cpp)
-target_link_libraries(subscriber_not_composable  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(subscriber_not_composable PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(subscriber_content_filtering content_filtering.cpp)
-target_link_libraries(subscriber_content_filtering  PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
+target_link_libraries(subscriber_content_filtering PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_library(wait_set_subscriber_library SHARED
     wait_set_subscriber.cpp
     static_wait_set_subscriber.cpp
     time_triggered_wait_set_subscriber.cpp)
-target_link_libraries(wait_set_subscriber_library  PRIVATE rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+target_link_libraries(wait_set_subscriber_library PRIVATE rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 
 rclcpp_components_register_node(wait_set_subscriber_library
     PLUGIN "WaitSetSubscriber"

--- a/rclcpp/wait_set/CMakeLists.txt
+++ b/rclcpp/wait_set/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(include)
 
 add_library(talker SHARED src/talker.cpp)
 target_compile_definitions(talker PRIVATE WAIT_SET_DLL)
-ament_target_dependencies(talker rclcpp rclcpp_components std_msgs)
+target_link_libraries(talker PUBLIC rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 rclcpp_components_register_node(
     talker
     PLUGIN "Talker"
@@ -29,36 +29,35 @@ rclcpp_components_register_node(
 
 add_library(listener SHARED src/listener.cpp)
 target_compile_definitions(listener PRIVATE WAIT_SET_DLL)
-ament_target_dependencies(listener rclcpp rclcpp_components std_msgs)
+target_link_libraries(listener PUBLIC rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 rclcpp_components_register_node(
     listener
     PLUGIN "Listener"
     EXECUTABLE wait_set_listener)
 
 add_executable(wait_set src/wait_set.cpp)
-ament_target_dependencies(wait_set example_interfaces rclcpp std_msgs)
+target_link_libraries(wait_set PRIVATE ${example_interfaces_TARGETS} rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(static_wait_set src/static_wait_set.cpp)
-ament_target_dependencies(static_wait_set rclcpp std_msgs)
+target_link_libraries(static_wait_set PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(thread_safe_wait_set src/thread_safe_wait_set.cpp)
-ament_target_dependencies(thread_safe_wait_set example_interfaces rclcpp std_msgs)
+target_link_libraries(thread_safe_wait_set PRIVATE ${example_interfaces_TARGETS} rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(wait_set_topics_and_timer src/wait_set_topics_and_timer.cpp)
-ament_target_dependencies(wait_set_topics_and_timer rclcpp std_msgs)
+target_link_libraries(wait_set_topics_and_timer PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(wait_set_random_order src/wait_set_random_order.cpp)
-ament_target_dependencies(wait_set_random_order rclcpp std_msgs)
+target_link_libraries(wait_set_random_order PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(executor_random_order src/executor_random_order.cpp)
-ament_target_dependencies(executor_random_order rclcpp std_msgs)
+target_link_libraries(executor_random_order PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(wait_set_topics_with_different_rates src/wait_set_topics_with_different_rates.cpp)
-ament_target_dependencies(wait_set_topics_with_different_rates rclcpp std_msgs)
+target_link_libraries(wait_set_topics_with_different_rates PRIVATE rclcpp::rclcpp ${std_msgs_TARGETS})
 
 add_executable(wait_set_composed src/wait_set_composed.cpp)
-target_link_libraries(wait_set_composed talker listener)
-ament_target_dependencies(wait_set_composed rclcpp)
+target_link_libraries(wait_set_composed PRIVATE talker listener rclcpp::rclcpp)
 
 install(TARGETS
     talker


### PR DESCRIPTION
`ament_target_dependencies()` hasn't been necessary for a while. This PR removes a bunch of uses of it. 

https://github.com/ament/ament_cmake/issues/292

Same branch name as:
* https://github.com/ros2/demos/pull/707