### PR TITLE
address flake8 errors for examples_rclpy_minimal_publisher.

### DIFF
--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function_with_wait_for_all_acked.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function_with_wait_for_all_acked.py
@@ -55,6 +55,7 @@ class MinimalPublisher(Node):
             self.i = 0
             self.timer.reset()
 
+
 def main(args=None):
     rclpy.init(args=args)
     minimal_publisher = MinimalPublisher()
@@ -64,6 +65,7 @@ def main(args=None):
         pass
     finally:
         rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/rclpy/topics/minimal_publisher/setup.py
+++ b/rclpy/topics/minimal_publisher/setup.py
@@ -35,7 +35,8 @@ setup(
             'publisher_member_function ='
             ' examples_rclpy_minimal_publisher.publisher_member_function:main',
             'publisher_member_function_with_wait_for_all_acked ='
-            ' examples_rclpy_minimal_publisher.publisher_member_function_with_wait_for_all_acked:main',
+            ' examples_rclpy_minimal_publisher.'
+            'publisher_member_function_with_wait_for_all_acked:main',
         ],
     },
 )


### PR DESCRIPTION
fix flake8 errors introduced by https://github.com/ros2/examples/pull/407