### PR TITLE
Improve readibility of reported thread ids in the multithreaded executor example

### DIFF
--- a/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
+++ b/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
 #include <thread>
-#include <algorithm>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"

--- a/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
+++ b/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
@@ -16,6 +16,8 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <algorithm>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -27,8 +29,13 @@ using namespace std::chrono_literals;
  **/
 std::string string_thread_id()
 {
-  auto hashed = std::hash<std::thread::id>()(std::this_thread::get_id());
-  return std::to_string(hashed);
+  static std::vector<std::thread::id> known_thread_ids {};
+  const auto thread_it = std::find(known_thread_ids.cbegin(), known_thread_ids.cend(), std::this_thread::get_id());
+  if (thread_it != known_thread_ids.end()){
+    return std::to_string(std::distance(known_thread_ids.cbegin(), thread_it));
+  }
+  known_thread_ids.push_back(std::this_thread::get_id());
+  return std::to_string(known_thread_ids.size() - 1);
 }
 
 /* For this example, we will be creating a publishing node like the one in minimal_publisher.

--- a/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
+++ b/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
@@ -32,7 +32,7 @@ std::string string_thread_id()
   static std::vector<std::thread::id> known_thread_ids {};
   const auto thread_it = std::find(known_thread_ids.cbegin(), known_thread_ids.cend(),
     std::this_thread::get_id());
-  if (thread_it != known_thread_ids.end()) {
+  if (thread_it != known_thread_ids.cend()) {
     return std::to_string(std::distance(known_thread_ids.cbegin(), thread_it));
   }
   known_thread_ids.push_back(std::this_thread::get_id());

--- a/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
+++ b/rclcpp/executors/multithreaded_executor/multithreaded_executor.cpp
@@ -30,8 +30,9 @@ using namespace std::chrono_literals;
 std::string string_thread_id()
 {
   static std::vector<std::thread::id> known_thread_ids {};
-  const auto thread_it = std::find(known_thread_ids.cbegin(), known_thread_ids.cend(), std::this_thread::get_id());
-  if (thread_it != known_thread_ids.end()){
+  const auto thread_it = std::find(known_thread_ids.cbegin(), known_thread_ids.cend(),
+    std::this_thread::get_id());
+  if (thread_it != known_thread_ids.end()) {
     return std::to_string(std::distance(known_thread_ids.cbegin(), thread_it));
   }
   known_thread_ids.push_back(std::this_thread::get_id());


### PR DESCRIPTION
Closes https://github.com/ros2/examples/issues/413

Assigns an arbitrary index to each thread to make it easier to identify the threads in the log output on systems with many CPU cores.