### PR TITLE
Fix CMAKE deprecation

### DIFF
--- a/rclcpp/actions/minimal_action_client/CMakeLists.txt
+++ b/rclcpp/actions/minimal_action_client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_action_client)
 
 # Default to C++17

--- a/rclcpp/actions/minimal_action_server/CMakeLists.txt
+++ b/rclcpp/actions/minimal_action_server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_action_server)
 
 # Default to C++17

--- a/rclcpp/composition/minimal_composition/CMakeLists.txt
+++ b/rclcpp/composition/minimal_composition/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_composition)
 
 # Default to C++17

--- a/rclcpp/executors/cbg_executor/CMakeLists.txt
+++ b/rclcpp/executors/cbg_executor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_cbg_executor)
 
 # Default to C++17

--- a/rclcpp/executors/multithreaded_executor/CMakeLists.txt
+++ b/rclcpp/executors/multithreaded_executor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_multithreaded_executor)
 
 # Default to C++17

--- a/rclcpp/services/async_client/CMakeLists.txt
+++ b/rclcpp/services/async_client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_async_client)
 
 # Default to C++17

--- a/rclcpp/services/minimal_client/CMakeLists.txt
+++ b/rclcpp/services/minimal_client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_client)
 
 # Default to C++17

--- a/rclcpp/services/minimal_service/CMakeLists.txt
+++ b/rclcpp/services/minimal_service/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_service)
 
 # Default to C++17

--- a/rclcpp/timers/minimal_timer/CMakeLists.txt
+++ b/rclcpp/timers/minimal_timer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_timer)
 
 # Default to C++17

--- a/rclcpp/topics/minimal_publisher/CMakeLists.txt
+++ b/rclcpp/topics/minimal_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_publisher)
 
 # Default to C++17

--- a/rclcpp/topics/minimal_subscriber/CMakeLists.txt
+++ b/rclcpp/topics/minimal_subscriber/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_minimal_subscriber)
 
 # Default to C++17

--- a/rclcpp/wait_set/CMakeLists.txt
+++ b/rclcpp/wait_set/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(examples_rclcpp_wait_set)
 
 # Default to C++17


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

cmake version < then 3.10 is deprecated

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
