### PR TITLE
Fix setuptools deprecations

### DIFF
--- a/launch_testing/launch_testing_examples/setup.py
+++ b/launch_testing/launch_testing_examples/setup.py
@@ -17,5 +17,9 @@ setup(
     maintainer_email='aditya.pande@openrobotics.org, alejandro@openrobotics.org',
     description='Examples of simple launch tests',
     license='Apache License 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
 )

--- a/rclpy/actions/minimal_action_client/setup.py
+++ b/rclpy/actions/minimal_action_client/setup.py
@@ -20,13 +20,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of action clients using rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'client = ' + package_name + '.client:main',

--- a/rclpy/actions/minimal_action_server/setup.py
+++ b/rclpy/actions/minimal_action_server/setup.py
@@ -20,13 +20,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of action servers using rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'server = ' + package_name + '.server:main',

--- a/rclpy/executors/setup.py
+++ b/rclpy/executors/setup.py
@@ -19,13 +19,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of creating and using exectors to run multiple nodes in rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'listener = examples_rclpy_executors.listener:main',

--- a/rclpy/guard_conditions/setup.py
+++ b/rclpy/guard_conditions/setup.py
@@ -17,13 +17,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of using guard conditions.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'trigger_guard_condition = '

--- a/rclpy/services/minimal_client/setup.py
+++ b/rclpy/services/minimal_client/setup.py
@@ -20,13 +20,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of minimal service clients using rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'client = examples_rclpy_minimal_client.client:main',

--- a/rclpy/services/minimal_service/setup.py
+++ b/rclpy/services/minimal_service/setup.py
@@ -20,13 +20,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of minimal service servers using rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'service = examples_rclpy_minimal_service.service:main',

--- a/rclpy/topics/minimal_publisher/setup.py
+++ b/rclpy/topics/minimal_publisher/setup.py
@@ -20,13 +20,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of minimal publishers using rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'publisher_old_school = examples_rclpy_minimal_publisher.publisher_old_school:main',

--- a/rclpy/topics/minimal_subscriber/setup.py
+++ b/rclpy/topics/minimal_subscriber/setup.py
@@ -20,13 +20,16 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
     description='Examples of minimal subscribers using rclpy.',
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'subscriber_old_school ='

--- a/rclpy/topics/pointcloud_publisher/setup.py
+++ b/rclpy/topics/pointcloud_publisher/setup.py
@@ -17,7 +17,11 @@ setup(
     maintainer_email='aditya.pande@openrobotics.org, alejandro@openrobotics.org',
     description='Example on how to publish a Pointcloud2 message',
     license='Apache 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'pointcloud_publisher = examples_rclpy_pointcloud_publisher.pointcloud_publisher:main'


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: Apache Software License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
