### PR TITLE
get rid of deprecated rclcpp::spin_some().

### DIFF
--- a/rclcpp/actions/minimal_action_client/member_functions.cpp
+++ b/rclcpp/actions/minimal_action_client/member_functions.cpp
@@ -134,9 +134,11 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto action_client = std::make_shared<MinimalActionClient>();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(action_client);
 
   while (!action_client->is_goal_done()) {
-    rclcpp::spin_some(action_client);
+    executor.spin_some();
   }
 
   rclcpp::shutdown();

--- a/rclcpp/topics/minimal_publisher/not_composable.cpp
+++ b/rclcpp/topics/minimal_publisher/not_composable.cpp
@@ -29,6 +29,8 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("minimal_publisher");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   auto publisher = node->create_publisher<std_msgs::msg::String>("topic", 10);
   std_msgs::msg::String message;
   auto publish_count = 0;
@@ -39,7 +41,7 @@ int main(int argc, char * argv[])
     RCLCPP_INFO(node->get_logger(), "Publishing: '%s'", message.data.c_str());
     try {
       publisher->publish(message);
-      rclcpp::spin_some(node);
+      executor.spin_some();
     } catch (const rclcpp::exceptions::RCLError & e) {
       RCLCPP_ERROR(
         node->get_logger(),


### PR DESCRIPTION
## Description

This depends on https://github.com/ros2/rclcpp/pull/2848

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
