### PR TITLE
Modify timer callback execution for ROS2 Humble

### DIFF
--- a/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
+++ b/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
@@ -71,8 +71,10 @@ public:
         case rclcpp::WaitResultKind::Ready:
           {
             if (wait_result.get_wait_set().get_rcl_wait_set().timers[0U]) {
-              if (auto data = timer_->call()) {
-                timer_->execute_callback(data);
+              // NOTE: In ROS2 Humble, TimerBase::execute_callback() no longer takes arguments.
+              // This replaces the old execute_callback(data) call from Foxy and earlier.
+              if (timer_->call()) {
+                timer_->execute_callback();
               }
             }
             break;

--- a/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
+++ b/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
@@ -74,7 +74,7 @@ public:
               // NOTE: In ROS2 Humble, TimerBase::execute_callback() no longer takes arguments.
               // This replaces the old execute_callback(data) call from Foxy and earlier.
               if (auto data = timer_->call()) {
-              #if RCLCPP_VERSION_MAJOR >= 16
+              #if RCLCPP_VERSION_MAJOR <= 16
                 timer_->execute_callback();
                 #else
                 timer_->execute_callback(data);

--- a/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
+++ b/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
@@ -73,8 +73,12 @@ public:
             if (wait_result.get_wait_set().get_rcl_wait_set().timers[0U]) {
               // NOTE: In ROS2 Humble, TimerBase::execute_callback() no longer takes arguments.
               // This replaces the old execute_callback(data) call from Foxy and earlier.
-              if (timer_->call()) {
+              if (auto data = timer_->call()) {
+                #if RCLCPP_VERSION >= RCLCPP_VERSION_COMBINED(Humble)
                 timer_->execute_callback();
+                #else
+                timer_->execute_callback(data);
+                #endif
               }
             }
             break;

--- a/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
+++ b/rclcpp/topics/minimal_subscriber/time_triggered_wait_set_subscriber.cpp
@@ -74,7 +74,7 @@ public:
               // NOTE: In ROS2 Humble, TimerBase::execute_callback() no longer takes arguments.
               // This replaces the old execute_callback(data) call from Foxy and earlier.
               if (auto data = timer_->call()) {
-                #if RCLCPP_VERSION >= RCLCPP_VERSION_COMBINED(Humble)
+              #if RCLCPP_VERSION_MAJOR >= 16
                 timer_->execute_callback();
                 #else
                 timer_->execute_callback(data);


### PR DESCRIPTION
Title:
Fix Humble API: execute_callback() no longer takes arguments

Description:
- In ROS2 Humble, TimerBase::execute_callback() no longer accepts any arguments.
- The example time_triggered_wait_set_subscriber.cpp previously called
  execute_callback(data), which fails to compile.
- This change updates the example to use execute_callback() with no arguments,
  and adds a comment above the line for future readers:

    // NOTE: In ROS2 Humble, TimerBase::execute_callback() no longer takes arguments

Tested by building with colcon and running the subscriber/publisher example.

Is this user-facing behavior change? No
Did you use Generative AI? No
Additional Information: Tested on ROS2 Humble LTS, Ubuntu 22.04.
