### PR TITLE
Improve minimal_publisher README with clearer structure and usage guidance

### DIFF
--- a/rclcpp/topics/minimal_publisher/README.md
+++ b/rclcpp/topics/minimal_publisher/README.md
@@ -1,5 +1,50 @@
-# Minimal publisher examples
+# Minimal Publisher Examples 
 
-This package contains a few different strategies for creating short nodes which blast out messages.
-The `talker_timer_lambda` and `talker_timer_member_function` recipes create subclasses of `rclcpp::Node` and set up an `rclcpp::timer` to periodically call functions which publish messages.
-The `talker_without_subclass` recipe instead instantiates a `rclcpp::Node` object *without* subclassing it, which works, but is not compatible with composition, and thus is no longer the recommended style for ROS 2 coding.
+This package provides several minimal examples demonstrating how to implement
+publisher nodes in ROS 2 using `rclcpp`.
+
+These examples are designed as learning references for new ROS 2 developers
+and illustrate different design patterns for publishing messages.
+
+### member_function.cpp
+Subclasses `rclcpp::Node` and uses a member function as the timer callback.
+
+This pattern is commonly used in ROS 2 and supports node composition when nodes are structured as classes.
+
+### lambda.cpp
+Uses a C++ lambda function as the timer callback.
+
+This approach is concise and suitable for simple publisher implementations.
+
+Both the lambda and member function patterns follow common ROS 2 best practices.  
+The only discouraged approach shown here is the `not_composable.cpp` example.
+
+### not_composable.cpp
+Creates a publisher without subclassing `rclcpp::Node`.
+
+While this pattern works, it does not support node composition and is generally discouraged in modern ROS 2 applications.
+
+### member_function_with_wait_for_all_acked.cpp
+Demonstrates how to wait until published messages are acknowledged before proceeding.
+Useful when reliable communication is required.
+
+### member_function_with_unique_network_flow_endpoints.cpp
+Shows advanced publisher configuration for unique network flow endpoints.
+Useful in complex distributed networking scenarios.
+
+## Build Instructions
+
+From the root of your ROS 2 workspace:
+
+```bash
+colcon build --packages-select examples_rclcpp_minimal_publisher
+source install/setup.bash
+```
+Each example corresponds to a different executable built from the source files listed above. The executable name matches the corresponding `
+.cpp` filename
+
+## Run Example
+
+```bash
+ros2 run examples_rclcpp_minimal_publisher member_function
+```


### PR DESCRIPTION
## Summary

This pull request improves the README for the `minimal_publisher` example in the rclcpp topics directory.

The previous README provided only a brief description of the examples. This update restructures the documentation to:

- Clearly describe each available example file
- Highlight recommended and discouraged design patterns
- Provide clearer build instructions
- Provide explicit run commands
- Improve readability and learning experience for new users

The goal is to make the example more approachable for beginners while preserving the minimal nature of the code.

---

## Type of Change

Documentation improvement only.  
No functional code changes were made.

---

## Is this user-facing behavior change?

No.  
This PR only improves documentation clarity and structure.

---

## Did you use Generative AI?

Yes. Generative AI assistance (ChatGPT, GPT-5.2-class model) was used to help structure and refine the documentation text.
All content was reviewed, understood, and validated before submission.

---

## Additional Information

This change aims to improve the onboarding experience for students and new ROS 2 users who rely on the minimal examples as learning references.