### PR TITLE
Add type hints to minimal publisher rclpy example

### DIFF
--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
@@ -12,31 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Optional
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
+from rclpy.publisher import Publisher
+from rclpy.timer import Timer
 
 from std_msgs.msg import String
 
 
 class MinimalPublisher(Node):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('minimal_publisher')
-        self.publisher_ = self.create_publisher(String, 'topic', 10)
+        self.publisher_: Publisher[String] = self.create_publisher(String, 'topic', 10)
         timer_period = 0.5  # seconds
-        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.timer: Timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
-    def timer_callback(self):
-        msg = String()
+    def timer_callback(self) -> None:
+        msg: String = String()
         msg.data = 'Hello World: %d' % self.i
         self.publisher_.publish(msg)
         self.get_logger().info('Publishing: "%s"' % msg.data)
         self.i += 1
 
 
-def main(args=None):
+def main(args: Optional[List[str]] = None) -> None:
     try:
         with rclpy.init(args=args):
             minimal_publisher = MinimalPublisher()


### PR DESCRIPTION
## Description

Add Python type hints to the minimal publisher rclpy example.

This updates function return types and adds annotations for the publisher, timer, and message variable.
No logic or behavior changes were made.

## Did you use Generative AI?

Yes, partially, with manual review.