### PR TITLE
Add type hints to minimal publisher rclpy example

### DIFF
--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
@@ -12,31 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Optional
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
+from rclpy.publisher import Publisher
+from rclpy.timer import Timer
 
 from std_msgs.msg import String
 
 
 class MinimalPublisher(Node):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('minimal_publisher')
-        self.publisher_ = self.create_publisher(String, 'topic', 10)
+        self.publisher_: Publisher[String] = self.create_publisher(String, 'topic', 10)
         timer_period = 0.5  # seconds
-        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.timer: Timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
-    def timer_callback(self):
-        msg = String()
+    def timer_callback(self) -> None:
+        msg: String = String()
         msg.data = 'Hello World: %d' % self.i
         self.publisher_.publish(msg)
         self.get_logger().info('Publishing: "%s"' % msg.data)
         self.i += 1
 
 
-def main(args=None):
+def main(args: Optional[List[str]] = None) -> None:
     try:
         with rclpy.init(args=args):
             minimal_publisher = MinimalPublisher()

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
-
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
-from rclpy.publisher import Publisher
-from rclpy.timer import Timer
 
 from std_msgs.msg import String
 
@@ -27,20 +23,20 @@ class MinimalPublisher(Node):
 
     def __init__(self) -> None:
         super().__init__('minimal_publisher')
-        self.publisher_: Publisher[String] = self.create_publisher(String, 'topic', 10)
+        self.publisher_ = self.create_publisher(String, 'topic', 10)
         timer_period = 0.5  # seconds
-        self.timer: Timer = self.create_timer(timer_period, self.timer_callback)
+        self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
     def timer_callback(self) -> None:
-        msg: String = String()
+        msg = String()
         msg.data = 'Hello World: %d' % self.i
         self.publisher_.publish(msg)
         self.get_logger().info('Publishing: "%s"' % msg.data)
         self.i += 1
 
 
-def main(args: Optional[List[str]] = None) -> None:
+def main(args=None) -> None:
     try:
         with rclpy.init(args=args):
             minimal_publisher = MinimalPublisher()

--- a/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+++ b/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Optional
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -36,7 +38,7 @@ class MinimalPublisher(Node):
         self.i += 1
 
 
-def main(args=None) -> None:
+def main(args: Optional[List[str]] = None) -> None:
     try:
         with rclpy.init(args=args):
             minimal_publisher = MinimalPublisher()


### PR DESCRIPTION
This PR adds Python type hints to the minimal publisher rclpy example.
It annotates function return types and key variables (publisher, timer, and message).
No logic or behavior has been changed.
The diff is intentionally minimal and limited to typing improvements only.