### PR TITLE
Rename spin_once to _spin_once_impl in custom executor

### DIFF
--- a/rclpy/executors/examples_rclpy_executors/custom_executor.py
+++ b/rclpy/executors/examples_rclpy_executors/custom_executor.py
@@ -56,7 +56,7 @@ class PriorityExecutor(Executor):
         # add_node inherited
         self.add_node(node)
 
-    def spin_once(self, timeout_sec=None):
+    def _spin_once_impl(self, timeout_sec=None):
         """
         Execute a single callback, then return.
 


### PR DESCRIPTION
Since https://github.com/ros2/rclpy/pull/1510, the `spin()` method calls `_spin_once_impl()` instead of `spin_once()`, so the method name has to be updated in the `custom_executor`

Test after applying the changes:

<img width="1853" height="1048" alt="Image" src="https://github.com/user-attachments/assets/ba117f31-6408-4762-b035-abc7f2de3a79" />